### PR TITLE
[MVP] #11 Concise Abstract Syntax API

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -203,6 +203,7 @@ pub fn map(items: Vec<(String, Expr)>) -> Expr {
     Expr::Map(to_map(items))
 }
 
+
 pub fn alist<T: Clone>(items: &[(&str, T)]) -> Vec<(String, T)> {
     items
 	.iter()

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,6 +6,15 @@ use std::ops::Deref;
 
 // Associative list macro for slices of named pairs with python-like
 // syntax.
+//
+// Basically converts this:
+//
+// alist!{"foo" => bar, "baz" => quux}
+//
+// To this:
+//
+// [("foo", bar), ("baz", bar)]
+//
 #[macro_export]
 macro_rules! alist(
     { $($key:expr => $value:expr),* } => {
@@ -16,6 +25,18 @@ macro_rules! alist(
 
 // Like the above, but implicitly uses String instead of &str, and
 // creates a collection instead of a slice.
+// Associative list macro for slices of named pairs with python-like
+// syntax.
+//
+// Basically converts this:
+//
+// map!{"foo" => bar, "baz" => quux}
+//
+// To this:
+//
+// [("foo".to_string(), bar), ("baz".to_string(), bar)]
+//
+// *and* places the result is placed into a collection.
 #[macro_export]
 macro_rules! map(
     { $($key:expr => $value:expr),* } => {
@@ -154,6 +175,15 @@ pub enum Expr {
 //
 // Basically, wouldn't be needed but for the distinction between []
 // and Vec, &str and string.
+//
+// Converts this:
+//
+// &[("foo", bar), ("baz", quux)]
+//
+// Into this:
+//
+// vec![("foo".to_string(), bar.clone()), ("baz".to_tring(), quux.clone())]
+//
 pub fn alist<T: Clone>(items: &[(&str, T)]) -> Vec<(String, T)> {
     items
 	.iter()

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -575,11 +575,10 @@ impl Builder {
 	Node::new(Statement::TypeDef(name.to_string(), t))
     }
 
-    // XXX: So far as I can tell this only gets used in the tests in parser.rs.
+    // This method is only used in unit tests in parser.rs.
     //
-    // It is really just a short-hand around cond clauses. I believe
-    // the statement variants of cond were actually factored out of
-    // grammar.lalrpop.
+    // It is really just a short-hand around cond clauses. It could be
+    // removed, and the tests re-written.
     pub fn guard(
 	&self,
 	clauses: &[(ExprNode, ExprNode)],

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -162,36 +162,6 @@ pub fn alist<T: Clone>(items: &[(&str, T)]) -> Vec<(String, T)> {
 }
 
 
-// XXX: This function is a candidate for removal, but keeping it for
-// now since it expresses some logic.
-pub fn union(lhs: TypeTag, rhs: TypeTag) -> TypeTag {
-    // automatically flatten unions together while we build the tree.
-    // Obviously this isn't efficient in terms of allocations. But
-    // we're hamstrung by the grammar.
-    match (lhs, rhs) {
-	(TypeTag::Union(lhs), TypeTag::Union(rhs)) => {
-	    let mut items = Vec::with_capacity(lhs.len() + rhs.len());
-	    items.extend(lhs.iter().cloned());
-	    items.extend(rhs.iter().cloned());
-	    TypeTag::Union(items)
-	}
-	(TypeTag::Union(lhs), rhs) => {
-	    let mut items = Vec::with_capacity(lhs.len() + 1);
-	    items.extend(lhs.iter().cloned());
-	    items.push(Node::new(rhs));
-	    TypeTag::Union(items)
-	},
-	(lhs, TypeTag::Union(rhs)) => {
-	    let mut items = Vec::with_capacity(rhs.len() + 1);
-	    items.push(Node::new(lhs));
-	    items.extend(rhs.iter().cloned());
-	    TypeTag::Union(items)
-	}
-	(lhs, rhs) => TypeTag::Union(vec!{Node::new(lhs), Node::new(rhs)})
-    }
-}
-
-
 // ADT for effects and structure
 #[derive(Clone, Debug, PartialEq)]
 pub enum Statement {
@@ -199,14 +169,6 @@ pub enum Statement {
     Emit(String, Seq<Expr>),
     Def(String, Node<Expr>),
     TypeDef(String, Node<TypeTag>),
-    // XXX: Body of MapIter / ListIter should be an expression. Then
-    // these themselves can be expressions, rather than statements.
-    //
-    // XXX: further, could we consider making fold and map part of the
-    // language, to be treated as core constructs, rather than
-    // higher-order procedures provided by a library.
-    //
-    // Alternatively, fold and map could be templates.
     ListIter(String, Node<Expr>, Node<Statement>),
     MapIter(String, String, Node<Expr>, Node<Statement>),
     While(Node<Expr>, Node<Statement>),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -11,6 +11,7 @@ use std::ops::Deref;
 // `sd::Rc`.
 pub type Node<T> = Rc<T>;
 pub type Seq<T> = Vec<Node<T>>;
+pub type PairSeq<T> = Vec<(Node<T>, Node<T>)>;
 pub type AList<T> = Vec<(String, Node<T>)>;
 pub type Map<T> = HashMap<String, Node<T>>;
 
@@ -129,7 +130,7 @@ pub enum Expr {
     Id(String),
     Dot(Node<Expr>, String),
     Index(Node<Expr>, Node<Expr>),
-    Cond(Seq<(Expr, Expr)>, Node<Expr>),
+    Cond(PairSeq<Expr>, Node<Expr>),
     Block(Seq<Statement>, Node<Expr>),
     BinOp(BinOp, Node<Expr>, Node<Expr>),
     UnOp(UnOp, Node<Expr>),
@@ -245,7 +246,12 @@ pub fn index(obj: Expr, e: Expr) -> Expr {
 
 
 pub fn cond(cases: Vec<(Expr, Expr)>, default: Expr) -> Expr {
-    Expr::Cond(to_seq(cases), Node::new(default))
+    let cases = cases
+	.iter()
+	.cloned()
+	.map(|case| (Node::new(case.0), Node::new(case.1)))
+	.collect();
+    Expr::Cond(cases, Node::new(default))
 }
 
 
@@ -375,6 +381,10 @@ pub fn guard(
 
     expr_for_effect(cond(clauses, default))
 }
+
+
+type SubExpr = Node<Expr>;
+type TypeExpr = Node<TypeTag>;
 
 
 // ADT for programs

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -4,7 +4,7 @@
 // https://github.com/vpzomtrrfrt/amath/blob/master/src/grammar.lalrpop
 
 use crate::ast;
-use crate::ast::Node;
+use crate::ast::{Node, ExprNode, TypeNode, StmtNode};
 use crate::ast::Builder;
 use std::str::FromStr;
 
@@ -18,7 +18,7 @@ pub Program: ast::Seq<ast::Statement>
 
 
 // Statement entry point.
-pub Statement: Node<ast::Statement> = {
+pub Statement: StmtNode = {
     FuncDef,
     ProcDef,
     TypeDef,
@@ -30,18 +30,18 @@ pub Statement: Node<ast::Statement> = {
 
 
 // Expression entry point.
-pub Expr: Node<ast::Expr> = {
+pub Expr: ExprNode = {
     Block,
     SimpleExpr
 }
 
 
 // Type Entry Point
-pub Type: Node<ast::TypeTag> = TypeExpr;
+pub Type: TypeNode = TypeExpr;
 
 
 // Syntactic sugar for Union(a, b)
-pub TypeExpr: Node<ast::TypeTag> = {
+pub TypeExpr: TypeNode = {
     <a:TypeExpr> "|" <b:TypeCons> => ast.union(&[a, b]),
     // If we had a Sum type, it would go here, and would look like this.
     // <a:TypeExpr> "+" <b:TypeCons> => ast.sum(&[a, b]),
@@ -51,7 +51,7 @@ pub TypeExpr: Node<ast::TypeTag> = {
 
 
 // Application of a type-level function: a type constructor.
-pub TypeCons: Node<ast::TypeTag> = {
+pub TypeCons: TypeNode = {
     <cons:TypeCons> "<" <types:Comma<Type>> ">"
 	=> Node::new(ast::TypeTag::TypeCons(cons, types.to_vec())),
     TypeTerm
@@ -59,7 +59,7 @@ pub TypeCons: Node<ast::TypeTag> = {
 
 
 // A primitive type, or a grouping of subtypes.
-pub TypeTerm: Node<ast::TypeTag> = {
+pub TypeTerm: TypeNode = {
     "Void"                      => ast.t_void.clone(),
     "Bool"                      => ast.t_bool.clone(),
     "Int"                       => ast.t_int.clone(),
@@ -76,7 +76,7 @@ pub TypeTerm: Node<ast::TypeTag> = {
 
 
 // Record types
-pub Record: Node<ast::TypeTag>
+pub Record: TypeNode
     = "{" <members:Semicolon<Member>> "}"
     => ast.record(&members);
 
@@ -95,13 +95,13 @@ pub Member: (&'input str, ast::Member) = {
 
 
 // Syntactic sugar for defining a function returning a value.
-FuncDef: Node<ast::Statement>
+FuncDef: StmtNode
     = "func" <name:Id> <args:Arglist> "->" <ret:Type> <body:Block>
     => ast.def(name, ast.lambda(&args, ret, body));
 
 
 // Syntatic sugar for defining a function which returns no value.
-ProcDef: Node<ast::Statement>
+ProcDef: StmtNode
     = "proc" <name:Id> <args:Arglist> <body:Block>
     => ast.def(name, ast.lambda(&args, ast.t_void.clone(), body));
 
@@ -115,25 +115,25 @@ ProcDef: Node<ast::Statement>
 // Templates can be called with the TemplateCall syntax, which
 // consumes a trailing block. This allows defining library functions
 // which feel like control structures.
-TemplateDef: Node<ast::Statement>
+TemplateDef: StmtNode
     = "template" <name:Id> <args:Arglist> "using" <delegate:Id> <body:Block>
     => ast.def(name, ast.template(&args, delegate, body));
 
 
 // The only way to introduce a type binding
-TypeDef: Node<ast::Statement>
+TypeDef: StmtNode
     = "type" <name:TypeName> ":" <t:Type> ";"
     => ast.typedef(name, t);
 
 
 // Used for raw cairo operations.
-Effect: Node<ast::Statement>
+Effect: StmtNode
     = "out" <name:Id> <exprs:ExprList> ";"
     => ast.emit(name, &exprs);
 
 
 // Bind a name to a value.
-Let: Node<ast::Statement>
+Let: StmtNode
     = "let" <name:Id> "=" <value:Expr> ";"
     => ast.def(name, value);
 
@@ -141,14 +141,14 @@ Let: Node<ast::Statement>
 // An expression evaluated for its side effects in a statement context.
 //
 // To keep the LALRPOP happy, this is a subset of expressions.
-EffectExpr: Node<ast::Statement> = {
+EffectExpr: StmtNode = {
     <Cond> => ast.expr_for_effect(<>),
     TemplateCall,
 }
 
 
 // Iterate over a collection.
-Iteration: Node<ast::Statement> = {
+Iteration: StmtNode = {
     "for" <name:Id> "in" <list:Expr> <body:Block>
 	=> ast.list_iter(name, list, ast.expr_for_effect(body)),
     "for" "(" <key:Id> "," <value:Id> ")" "in" <map:Expr> <body:Block>
@@ -159,7 +159,7 @@ Iteration: Node<ast::Statement> = {
 // Any expression which is not a Block.
 //
 // Needed to avoid the abiguity of nesting blocks.
-SimpleExpr: Node<ast::Expr> = {
+SimpleExpr: ExprNode = {
     Lambda,
     Cond,
     Logic,
@@ -167,7 +167,7 @@ SimpleExpr: Node<ast::Expr> = {
 
 
 // An if-else chain
-Cond: Node<ast::Expr>
+Cond: ExprNode
     = "if"
       <first:CondClause>
       <rest:("elif" <CondClause>)*>
@@ -181,25 +181,25 @@ Cond: Node<ast::Expr>
 
 
 // Single clause in an if-else chain
-CondClause: (Node<ast::Expr>, Node<ast::Expr>)
+CondClause: (ExprNode, ExprNode)
     = "(" <pred: Expr> ")" <body: Block>
     => (pred, body);
 
 
 // Single paramater in a function signature
-Param: (&'input str, Node<ast::TypeTag>)
+Param: (&'input str, TypeNode)
     = <name:Id> ":" <t:Type>
     => (name, t);
 
 
 // The argument list of a function signature
-Arglist: Vec<(&'input str, Node<ast::TypeTag>)>
+Arglist: Vec<(&'input str, TypeNode)>
     = "(" <args:Comma<Param>> ")"
     => args;
 
 
 // An anonymous function expression.
-Lambda: Node<ast::Expr>
+Lambda: ExprNode
     = <args:Arglist> <ret:("->" <Type>)?> "=" <body:Expr>
     => ast.lambda(
 	&args,
@@ -211,7 +211,7 @@ Lambda: Node<ast::Expr>
 // A sequence of statements treated as an expression.
 //
 // If the `yield` keyword is present, then this block has a value.
-Block: Node<ast::Expr> = {
+Block: ExprNode = {
     "{" <stmts:Statement+> <ret:("yield" <SimpleExpr>)?> "}"
         => ast.block(&stmts, ret.unwrap_or(ast.void.clone())),
     "{" <ret:("yield" <SimpleExpr>)> "}"
@@ -221,7 +221,7 @@ Block: Node<ast::Expr> = {
 
 // Expression entry point anow, this is the logic operators. This way
 // sloppily-parenthesized logic hould do the least surprising thing.
-Logic: Node<ast::Expr> = {
+Logic: ExprNode = {
     <a:Logic> "and" <b:Rel> => ast.bin(ast::BinOp::And, a, b),
     <a:Logic> "or"  <b:Rel> => ast.bin(ast::BinOp::Or, a, b),
     <a:Logic> "xor" <b:Rel> => ast.bin(ast::BinOp::Xor, a, b),
@@ -230,7 +230,7 @@ Logic: Node<ast::Expr> = {
 
 
 // Relational operators are the next highest precedence.
-Rel: Node<ast::Expr> = {
+Rel: ExprNode = {
     <a:Rel> "<"  <b:Sum> => ast.bin(ast::BinOp::Lt, a, b),
     <a:Rel> ">"  <b:Sum> => ast.bin(ast::BinOp::Gt, a, b),
     <a:Rel> "<=" <b:Sum> => ast.bin(ast::BinOp::Lte, a, b),
@@ -240,21 +240,21 @@ Rel: Node<ast::Expr> = {
 };
 
 
-Sum: Node<ast::Expr> = {
+Sum: ExprNode = {
     <a:Sum> "+" <b:Factor> => ast.bin(ast::BinOp::Add, a, b),
     <a:Sum> "-" <b:Factor> => ast.bin(ast::BinOp::Sub, a, b),
     Factor,
 };
 
 
-Factor: Node<ast::Expr> = {
+Factor: ExprNode = {
     <a:Factor> "*" <b:Exp> => ast.bin(ast::BinOp::Mul, a, b),
     <a:Factor> "/" <b:Exp> => ast.bin(ast::BinOp::Div, a, b),
     Exp
 };
 
 
-Exp: Node<ast::Expr> = {
+Exp: ExprNode = {
     <base:Exp> "^" <exp: InvTerm> => ast.bin(ast::BinOp::Pow, base, exp),
     InvTerm
 }
@@ -264,7 +264,7 @@ Exp: Node<ast::Expr> = {
 // right thing. I.e. -foo() should parse as (- (foo)), not ((- foo)).
 //
 // The same thing applies to logical negation.
-InvTerm: Node<ast::Expr> = {
+InvTerm: ExprNode = {
     "-" <a:InvTerm> => ast.un(ast::UnOp::Neg, a),
     "not" <a:InvTerm> => ast.un(ast::UnOp::Not, a),
     Call
@@ -278,7 +278,7 @@ InvTerm: Node<ast::Expr> = {
 //
 // To simplify the grammar, templates are assumed not to return a
 // value and are purely used for their effects.
-TemplateCall: Node<ast::Statement> = {
+TemplateCall: StmtNode = {
     <func:Selection> "(" <args:ExprList> ")" <delegate:Block>
 	=> ast.template_call(func, &args, delegate),
     <func:Selection> "(" <args:ExprList> ")" ";"
@@ -288,14 +288,14 @@ TemplateCall: Node<ast::Statement> = {
 
 // We want indexing and selection to bind before function calls, so that
 // foo.bar(a) parses as ((dot foo bar) a), not (dot foo (bar a))
-Call: Node<ast::Expr> = {
+Call: ExprNode = {
     <func:Call> "(" <args:ExprList> ")" => ast.call(func, &args),
     Selection
 }
 
 
 // XXX: see github issue #13
-Selection: Node<ast::Expr> = {
+Selection: ExprNode = {
     <obj:Selection> "." <id:Id> => ast.dot(obj, id),
     <obj:Selection> "[" <e:Expr> "]" => ast.index(obj, e),
     Term
@@ -303,7 +303,7 @@ Selection: Node<ast::Expr> = {
 
 
 // Literals of any type except lambdas.
-Term: Node<ast::Expr> = {
+Term: ExprNode = {
     "self" => ast.this.clone(),
     Id => ast.id(<>),
     Int => ast.i(<>),
@@ -317,7 +317,7 @@ Term: Node<ast::Expr> = {
 
 
 // A single item in a map.
-MapItem: (&'input str, Node<ast::Expr>) = {
+MapItem: (&'input str, ExprNode) = {
     <k:Str> ":" <v:Logic> => (k, v),
     <k:Id> ":" <v:Logic> => (k, v)
 }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -13,12 +13,12 @@ grammar(ast: &Builder);
 
 
 // Program Entry Point
-pub Program: Vec<ast::Statement>
+pub Program: ast::Seq<ast::Statement>
     = "Version" ":" ".1-alpha" ";" <Statement*>;
 
 
 // Statement entry point.
-pub Statement: ast::Statement = {
+pub Statement: Node<ast::Statement> = {
     FuncDef,
     ProcDef,
     TypeDef,
@@ -30,80 +30,80 @@ pub Statement: ast::Statement = {
 
 
 // Expression entry point.
-pub Expr: ast::Expr = {
+pub Expr: Node<ast::Expr> = {
     Block,
-    SimpleExpr,
+    SimpleExpr
 }
 
 
 // Type Entry Point
-pub Type: ast::TypeTag = TypeExpr;
+pub Type: Node<ast::TypeTag> = TypeExpr;
 
 
 // Syntactic sugar for Union(a, b)
-pub TypeExpr: ast::TypeTag = {
-    <a:TypeExpr> "|" <b:TypeCons> => ast::union(a, b),
+pub TypeExpr: Node<ast::TypeTag> = {
+    <a:TypeExpr> "|" <b:TypeCons> => ast.union(&[a, b]),
     // If we had a Sum type, it would go here, and would look like this.
-    //<a:TypeExpr> "+" <b:TypeCons> => ast::TypeTag::Sum(Node::new(a), Node::new(b)),
-    <TypeCons>   "?"              => ast::TypeTag::Option(Node::new(<>)),
-    TypeCons
+    // <a:TypeExpr> "+" <b:TypeCons> => ast.sum(&[a, b]),
+    <TypeCons>   "?"              => ast.option(<>),
+    TypeCons,
 }
 
 
 // Application of a type-level function: a type constructor.
-pub TypeCons: ast::TypeTag = {
+pub TypeCons: Node<ast::TypeTag> = {
     <cons:TypeCons> "<" <types:Comma<Type>> ">"
-    	=> ast::TypeTag::TypeCons(ast::Node::new(cons), ast::to_seq(types)),
+	=> Node::new(ast::TypeTag::TypeCons(cons, types.to_vec())),
     TypeTerm
 }
 
 
 // A primitive type, or a grouping of subtypes.
-pub TypeTerm: ast::TypeTag = {
-    "Void"                      => ast::TypeTag::Void,
-    "Bool"                      => ast::TypeTag::Bool,
-    "Int"                       => ast::TypeTag::Int,
-    "Float"                     => ast::TypeTag::Float,
-    "Str"                       => ast::TypeTag::Str,
-    "Point"                     => ast::TypeTag::Point,
-    "Self"                      => ast::TypeTag::This,                    
-    <TypeName>                  => ast::TypeTag::TypeName(<>.to_string()),
+pub TypeTerm: Node<ast::TypeTag> = {
+    "Void"                      => ast.t_void.clone(),
+    "Bool"                      => ast.t_bool.clone(),
+    "Int"                       => ast.t_int.clone(),
+    "Float"                     => ast.t_float.clone(),
+    "Str"                       => ast.t_str.clone(),
+    "Point"                     => ast.t_point.clone(),
+    "Self"                      => ast.t_this.clone(),
+    <TypeName>                  => ast.type_name(<>),
     <Record>                    => <>,
     "(" <Type> ")"              => <>,
-    "<" <items:Comma<Type>> ">" => ast::TypeTag::Tuple(ast::to_seq(items)),
-    "[" <items:Type> "]"        => ast::TypeTag::List(ast::Node::new(items))
+    "<" <items:Comma<Type>> ">" => ast.tuple(&items),
+    "[" <item:Type> "]"         => ast.t_list(item)
 }
 
 
 // Record types
-pub Record: ast::TypeTag
+pub Record: Node<ast::TypeTag>
     = "{" <members:Semicolon<Member>> "}"
-    => ast::TypeTag::Record(ast::to_alist(members));
+    => ast.record(&members);
 
 
 // Any field in a record type.
-pub Member: (String, ast::Member) = {
+pub Member: (&'input str, ast::Member) = {
     "field" <name:Id> ":" <t:Type>
-	=> (name, ast::Member::Field(ast::Node::new(t))),
+	=> ast.field(name, t),
     "method" <name:Id> <args:Arglist> "->" <ret:Type> "=" <body:Expr>
-	=> (name, ast::Member::Method(args, Node::new(ret), Node::new(body))),
+	=> ast.method(name, &args, ret, body),
     "const" <name:Id> ":" <t:Type> "=" <value:Expr>
-	=> (name, ast::Member::StaticValue(Node::new(t), ast::Node::new(value))),
+	=> ast.static_val(name, t, value),
     "static" <name:Id> <args:Arglist> "->" <ret:Type> "=" <body:Expr>
-	=> (name, ast::Member::StaticMethod(args, Node::new(ret), Node::new(body)))
+	=> ast.static_method(name, &args, ret, body),
 }
 
 
 // Syntactic sugar for defining a function returning a value.
-FuncDef: ast::Statement
+FuncDef: Node<ast::Statement>
     = "func" <name:Id> <args:Arglist> "->" <ret:Type> <body:Block>
-    => ast::def(name.as_str(), ast::lambda(args, ret, body));
+    => ast.def(name, ast.lambda(&args, ret, body));
 
 
 // Syntatic sugar for defining a function which returns no value.
-ProcDef: ast::Statement
+ProcDef: Node<ast::Statement>
     = "proc" <name:Id> <args:Arglist> <body:Block>
-    => ast::def(name.as_str(), ast::lambda(args, ast::TypeTag::Void, body));
+    => ast.def(name, ast.lambda(&args, ast.t_void.clone(), body));
 
 
 // Syntactic sugar for defining a template function.
@@ -115,56 +115,51 @@ ProcDef: ast::Statement
 // Templates can be called with the TemplateCall syntax, which
 // consumes a trailing block. This allows defining library functions
 // which feel like control structures.
-TemplateDef: ast::Statement
+TemplateDef: Node<ast::Statement>
     = "template" <name:Id> <args:Arglist> "using" <delegate:Id> <body:Block>
-    => ast::def(name.as_str(), ast::template(args, delegate.as_str(), body));
+    => ast.def(name, ast.template(&args, delegate, body));
 
 
 // The only way to introduce a type binding
-TypeDef: ast::Statement
+TypeDef: Node<ast::Statement>
     = "type" <name:TypeName> ":" <t:Type> ";"
-    => ast::typedef(name.as_str(), t);
+    => ast.typedef(name, t);
 
 
 // Used for raw cairo operations.
-Effect: ast::Statement
+Effect: Node<ast::Statement>
     = "out" <name:Id> <exprs:ExprList> ";"
-    => ast::emit(name.as_str(), exprs);
+    => ast.emit(name, &exprs);
 
 
 // Bind a name to a value.
-Let: ast::Statement
+Let: Node<ast::Statement>
     = "let" <name:Id> "=" <value:Expr> ";"
-    => ast::def(name.as_str(), value);
+    => ast.def(name, value);
 
 
 // An expression evaluated for its side effects in a statement context.
 //
 // To keep the LALRPOP happy, this is a subset of expressions.
-EffectExpr: ast::Statement = {
-    <Cond> => ast::expr_for_effect(<>),
+EffectExpr: Node<ast::Statement> = {
+    <Cond> => ast.expr_for_effect(<>),
     TemplateCall,
 }
 
 
 // Iterate over a collection.
-Iteration: ast::Statement = {
+Iteration: Node<ast::Statement> = {
     "for" <name:Id> "in" <list:Expr> <body:Block>
-	=> ast::list_iter(name.as_str(), list, ast::expr_for_effect(body)),
+	=> ast.list_iter(name, list, ast.expr_for_effect(body)),
     "for" "(" <key:Id> "," <value:Id> ")" "in" <map:Expr> <body:Block>
-	=> ast::map_iter(
-	    key.as_str(),
-	    value.as_str(),
-	    map,
-	    ast::expr_for_effect(body)
-	)
+	=> ast.map_iter(key, value, map, ast.expr_for_effect(body))
 }
 
 
 // Any expression which is not a Block.
 //
 // Needed to avoid the abiguity of nesting blocks.
-SimpleExpr: ast::Expr = {
+SimpleExpr: Node<ast::Expr> = {
     Lambda,
     Cond,
     Logic,
@@ -172,7 +167,7 @@ SimpleExpr: ast::Expr = {
 
 
 // An if-else chain
-Cond: ast::Expr
+Cond: Node<ast::Expr>
     = "if"
       <first:CondClause>
       <rest:("elif" <CondClause>)*>
@@ -180,34 +175,35 @@ Cond: ast::Expr
     => {
         let mut clauses = vec!{first};
         clauses.extend(rest);
-        ast::cond(clauses, default.unwrap_or(ast::Expr::Void))
+        ast.cond(clauses.as_slice(), default.unwrap_or(ast.void.clone()))
     }
 ;
 
 
 // Single clause in an if-else chain
-CondClause: (ast::Expr, ast::Expr) = {
-    "(" <pred: Expr> ")" <body: Block>
-        => (pred, body),
-}
+CondClause: (Node<ast::Expr>, Node<ast::Expr>)
+    = "(" <pred: Expr> ")" <body: Block>
+    => (pred, body);
 
 
 // Single paramater in a function signature
-Param: (String, ast::TypeTag) =
-    <name:Id> ":" <t:Type> => (name, t);
+Param: (&'input str, Node<ast::TypeTag>)
+    = <name:Id> ":" <t:Type>
+    => (name, t);
 
 
 // The argument list of a function signature
-Arglist: ast::AList<ast::TypeTag> =
-    "(" <args:Comma<Param>> ")" => ast::to_alist(args);
+Arglist: Vec<(&'input str, Node<ast::TypeTag>)>
+    = "(" <args:Comma<Param>> ")"
+    => args;
 
 
 // An anonymous function expression.
-Lambda: ast::Expr
+Lambda: Node<ast::Expr>
     = <args:Arglist> <ret:("->" <Type>)?> "=" <body:Expr>
-    => ast::lambda(
-	args,
-	ret.unwrap_or(ast::TypeTag::Void),
+    => ast.lambda(
+	&args,
+	ret.unwrap_or(ast.t_void.clone()),
 	body
     );
 
@@ -215,50 +211,51 @@ Lambda: ast::Expr
 // A sequence of statements treated as an expression.
 //
 // If the `yield` keyword is present, then this block has a value.
-Block: ast::Expr = {
+Block: Node<ast::Expr> = {
     "{" <stmts:Statement+> <ret:("yield" <SimpleExpr>)?> "}"
-        => ast::expr_block(stmts, ret.unwrap_or(ast::Expr::Void)),
-    "{" <ret:("yield" <SimpleExpr>)> "}" => ret,
+        => ast.block(&stmts, ret.unwrap_or(ast.void.clone())),
+    "{" <ret:("yield" <SimpleExpr>)> "}"
+	=> ret,
 }
 
 
 // Expression entry point anow, this is the logic operators. This way
 // sloppily-parenthesized logic hould do the least surprising thing.
-Logic: ast::Expr = {
-    <a:Logic> "and" <b:Rel> => ast::bin(ast::BinOp::And, a, b),
-    <a:Logic> "or"  <b:Rel> => ast::bin(ast::BinOp::Or, a, b),
-    <a:Logic> "xor" <b:Rel> => ast::bin(ast::BinOp::Xor, a, b),
+Logic: Node<ast::Expr> = {
+    <a:Logic> "and" <b:Rel> => ast.bin(ast::BinOp::And, a, b),
+    <a:Logic> "or"  <b:Rel> => ast.bin(ast::BinOp::Or, a, b),
+    <a:Logic> "xor" <b:Rel> => ast.bin(ast::BinOp::Xor, a, b),
     Rel
 }
 
 
 // Relational operators are the next highest precedence.
-Rel: ast::Expr = {
-    <a:Rel> "<"  <b:Sum> => ast::bin(ast::BinOp::Lt, a, b),
-    <a:Rel> ">"  <b:Sum> => ast::bin(ast::BinOp::Gt, a, b),
-    <a:Rel> "<=" <b:Sum> => ast::bin(ast::BinOp::Lte, a, b),
-    <a:Rel> ">=" <b:Sum> => ast::bin(ast::BinOp::Gte, a, b),
-    <a:Rel> "==" <b:Sum> => ast::bin(ast::BinOp::Eq, a, b),
+Rel: Node<ast::Expr> = {
+    <a:Rel> "<"  <b:Sum> => ast.bin(ast::BinOp::Lt, a, b),
+    <a:Rel> ">"  <b:Sum> => ast.bin(ast::BinOp::Gt, a, b),
+    <a:Rel> "<=" <b:Sum> => ast.bin(ast::BinOp::Lte, a, b),
+    <a:Rel> ">=" <b:Sum> => ast.bin(ast::BinOp::Gte, a, b),
+    <a:Rel> "==" <b:Sum> => ast.bin(ast::BinOp::Eq, a, b),
     Sum
 };
 
 
-Sum: ast::Expr = {
-    <a:Sum> "+" <b:Factor> => ast::bin(ast::BinOp::Add, a, b),
-    <a:Sum> "-" <b:Factor> => ast::bin(ast::BinOp::Sub, a, b),
+Sum: Node<ast::Expr> = {
+    <a:Sum> "+" <b:Factor> => ast.bin(ast::BinOp::Add, a, b),
+    <a:Sum> "-" <b:Factor> => ast.bin(ast::BinOp::Sub, a, b),
     Factor,
 };
 
 
-Factor: ast::Expr = {
-    <a:Factor> "*" <b:Exp> => ast::bin(ast::BinOp::Mul, a, b),
-    <a:Factor> "/" <b:Exp> => ast::bin(ast::BinOp::Div, a, b),
+Factor: Node<ast::Expr> = {
+    <a:Factor> "*" <b:Exp> => ast.bin(ast::BinOp::Mul, a, b),
+    <a:Factor> "/" <b:Exp> => ast.bin(ast::BinOp::Div, a, b),
     Exp
 };
 
 
-Exp: ast::Expr = {
-    <base:Exp> "^" <exp: InvTerm> => ast::bin(ast::BinOp::Pow, base, exp),
+Exp: Node<ast::Expr> = {
+    <base:Exp> "^" <exp: InvTerm> => ast.bin(ast::BinOp::Pow, base, exp),
     InvTerm
 }
 
@@ -267,9 +264,9 @@ Exp: ast::Expr = {
 // right thing. I.e. -foo() should parse as (- (foo)), not ((- foo)).
 //
 // The same thing applies to logical negation.
-InvTerm: ast::Expr = {
-    "-" <a:InvTerm> => ast::un(ast::UnOp::Neg, a),
-    "not" <a:InvTerm> => ast::un(ast::UnOp::Not, a),
+InvTerm: Node<ast::Expr> = {
+    "-" <a:InvTerm> => ast.un(ast::UnOp::Neg, a),
+    "not" <a:InvTerm> => ast.un(ast::UnOp::Not, a),
     Call
 };
 
@@ -281,46 +278,46 @@ InvTerm: ast::Expr = {
 //
 // To simplify the grammar, templates are assumed not to return a
 // value and are purely used for their effects.
-TemplateCall: ast::Statement = {
+TemplateCall: Node<ast::Statement> = {
     <func:Selection> "(" <args:ExprList> ")" <delegate:Block>
-	=> ast::template_call(func, args, delegate),
+	=> ast.template_call(func, &args, delegate),
     <func:Selection> "(" <args:ExprList> ")" ";"
-        => ast::expr_for_effect(ast::call(func, args))
+        => ast.expr_for_effect(ast.call(func, &args))
 };
 
 
 // We want indexing and selection to bind before function calls, so that
 // foo.bar(a) parses as ((dot foo bar) a), not (dot foo (bar a))
-Call: ast::Expr = {
-    <func:Call> "(" <args:ExprList> ")" => ast::call(func, args),
+Call: Node<ast::Expr> = {
+    <func:Call> "(" <args:ExprList> ")" => ast.call(func, &args),
     Selection
 }
 
 
 // XXX: see github issue #13
-Selection: ast::Expr = {
-    <obj:Selection> "." <id:Id> => ast::dot(obj, id.as_str()),
-    <obj:Selection> "[" <e:Expr> "]" => ast::index(obj, e),
+Selection: Node<ast::Expr> = {
+    <obj:Selection> "." <id:Id> => ast.dot(obj, id),
+    <obj:Selection> "[" <e:Expr> "]" => ast.index(obj, e),
     Term
 }
 
 
 // Literals of any type except lambdas.
-Term: ast::Expr = {
-    "self" => ast::Expr::This,
-    Id => ast::Expr::Id(<>),
-    Int => ast::Expr::Int(<>),
-    Float => ast::Expr::Float(<>),
-    Str => ast::Expr::Str(<>),
-    Boolean => ast::Expr::Bool(<>),
+Term: Node<ast::Expr> = {
+    "self" => ast.this.clone(),
+    Id => ast.id(<>),
+    Int => ast.i(<>),
+    Float => ast.f(<>),
+    Str => ast.s(<>),
+    Boolean => ast.b(<>),
     "(" <a:Expr> ")" => a,
-    "[" <l:ExprList> "]" => ast::list(l),
-    "{" <m:MapItems> "}" => ast::map(m),
+    "[" <l:ExprList> "]" => ast.list(&l),
+    "{" <m:MapItems> "}" => ast.map(&m),
 };
 
 
 // A single item in a map.
-MapItem: (String, ast::Expr) = {
+MapItem: (&'input str, Node<ast::Expr>) = {
     <k:Str> ":" <v:Logic> => (k, v),
     <k:Id> ":" <v:Logic> => (k, v)
 }
@@ -361,9 +358,9 @@ Semicolon<T>: Vec<T> = {
 
 
 // Terminals
-Int: i64 = r"-?[0-9]+" => i64::from_str(<>).unwrap();
-Float: f64 = r"-?[0-9]+\.[0-9]+" => f64::from_str(<>).unwrap();
-Id: String = r"[a-z_][A-Za-z0-9_]*" => <>.to_owned();
-TypeName: String = r"[A-Z][A-Za-z0-9_]*" => <>.to_owned();
-Boolean: bool = {"true" => true, "false" => false};
-Str: String = <s:r#""(([^\\"]|\\.)*)""#> => s[1..(s.len() - 1)].to_string();
+Int: i64              = r"-?[0-9]+" => i64::from_str(<>).unwrap();
+Float: f64            = r"-?[0-9]+\.[0-9]+" => f64::from_str(<>).unwrap();
+Id: &'input str       = r"[a-z_][A-Za-z0-9_]*" => <>;
+TypeName: &'input str = r"[A-Z][A-Za-z0-9_]*" => <>;
+Boolean: bool         = {"true" => true, "false" => false};
+Str: &'input str      = <s:r#""(([^\\"]|\\.)*)""#> => &s[1..(s.len() - 1)];

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -5,10 +5,11 @@
 
 use crate::ast;
 use crate::ast::Node;
+use crate::ast::Builder;
 use std::str::FromStr;
 
 
-grammar;
+grammar(ast: &Builder);
 
 
 // Program Entry Point

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 #[macro_use]
 extern crate lalrpop_util;
 
+#[macro_use]
 pub mod ast;
 pub mod env;
 lalrpop_mod!(pub grammar);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,7 +30,7 @@ mod tests {
     
     // Helper functions for test cases.
 
-    fn assert_expr(text: &'static str, ast: ast::SubExpr) {
+    fn assert_expr(text: &'static str, ast: ast::ExprNode) {
 	let builder = ast::Builder::new();
         assert_eq!(
             grammar::ExprParser::new().parse(&builder, text).unwrap(),
@@ -38,7 +38,7 @@ mod tests {
         );
     }
 
-    fn assert_statement(text: &'static str, ast: Node<Statement>) {
+    fn assert_statement(text: &'static str, ast: StmtNode) {
 	let builder = ast::Builder::new();
         assert_eq!(
             grammar::StatementParser::new().parse(&builder, text).unwrap(),
@@ -46,7 +46,7 @@ mod tests {
         );
     }
 
-    fn assert_type(text: &'static str, ast: ast::Node<TypeTag>) {
+    fn assert_type(text: &'static str, ast: ast::TypeNode) {
 	let builder = ast::Builder::new();
         assert_eq!(
 	    grammar::TypeParser::new().parse(&builder, text).unwrap(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,7 +33,7 @@ mod tests {
     fn assert_expr(text: &'static str, ast: ast::SubExpr) {
 	let builder = ast::Builder::new();
         assert_eq!(
-            Node::new(grammar::ExprParser::new().parse(&builder, text).unwrap()),
+            grammar::ExprParser::new().parse(&builder, text).unwrap(),
             ast
         );
     }
@@ -41,7 +41,7 @@ mod tests {
     fn assert_statement(text: &'static str, ast: Node<Statement>) {
 	let builder = ast::Builder::new();
         assert_eq!(
-            Node::new(grammar::StatementParser::new().parse(&builder, text).unwrap()),
+            grammar::StatementParser::new().parse(&builder, text).unwrap(),
             ast
         );
     }
@@ -49,7 +49,7 @@ mod tests {
     fn assert_type(text: &'static str, ast: ast::Node<TypeTag>) {
 	let builder = ast::Builder::new();
         assert_eq!(
-	    Node::new(grammar::TypeParser::new().parse(&builder, text).unwrap()),
+	    grammar::TypeParser::new().parse(&builder, text).unwrap(),
             ast
         );
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,6 @@ mod tests {
     use crate::grammar;
     use crate::ast;
     use crate::ast::*;
-    use Expr::*;
     use ast::BinOp::*;
     use ast::UnOp::*;
 
@@ -31,23 +30,23 @@ mod tests {
     
     // Helper functions for test cases.
 
-    fn assert_expr(text: &'static str, ast: Expr) {
+    fn assert_expr(text: &'static str, ast: ast::SubExpr) {
         assert_eq!(
-            grammar::ExprParser::new().parse(text).unwrap(),
+            Node::new(grammar::ExprParser::new().parse(text).unwrap()),
             ast
         );
     }
 
-    fn assert_statement(text: &'static str, ast: Statement) {
+    fn assert_statement(text: &'static str, ast: Node<Statement>) {
         assert_eq!(
-            grammar::StatementParser::new().parse(text).unwrap(),
+            Node::new(grammar::StatementParser::new().parse(text).unwrap()),
             ast
         );
     }
 
-    fn assert_type(text: &'static str, ast: TypeTag) {
+    fn assert_type(text: &'static str, ast: ast::Node<TypeTag>) {
         assert_eq!(
-	    grammar::TypeParser::new().parse(text).unwrap(),
+	    Node::new(grammar::TypeParser::new().parse(text).unwrap()),
             ast
         );
     }
@@ -56,213 +55,226 @@ mod tests {
 
     #[test]
     fn test_basic() {
-        assert_expr("3 + 4 * 5", bin(
+	let ast = Builder::new();
+        assert_expr("3 + 4 * 5", ast.bin(
             Add,
-            Int(3),
-            bin(Mul, Int(4), Int(5))
+            ast.i(3),
+            ast.bin(Mul, ast.i(4), ast.i(5))
         ));
-        assert_expr("a + 3", bin(Add, Id(s("a")), Int(3)));
-        assert_expr("3 * a", bin(Mul, Int(3), id("a")));
-        assert_expr("\"foo\"", string("foo"));
+        assert_expr("a + 3", ast.bin(Add, ast.id("a"), ast.i(3)));
+        assert_expr("3 * a", ast.bin(Mul, ast.i(3), ast.id("a")));
+        assert_expr("\"foo\"", ast.s("foo"));
 
     }
 
     #[test]
     fn test_list() {
-        assert_expr("[]", list(vec!{}));
-        assert_expr("[3]", list(vec!{Int(3)}));
-        assert_expr("[3, 4, 5]", list(vec!{Int(3), Int(4), Int(5)}));
+	let ast = Builder::new();
+        assert_expr("[]", ast.list(&[]));
+        assert_expr("[3]", ast.list(&[ast.i(3)]));
+        assert_expr("[3, 4, 5]", ast.list(&[ast.i(3), ast.i(4), ast.i(5)]));
         assert_expr(
             "[3 + 4, 5]",
-            list(vec!{bin(Add, Int(3), Int(4)), Int(5)})
+            ast.list(&[ast.bin(Add, ast.i(3), ast.i(4)), ast.i(5)])
         );
     }
 
     #[test]
     fn test_map() {
-        assert_expr("{}", map(vec!{}));
+	let ast = Builder::new();
+        assert_expr("{}", ast.map(&[]));
         assert_expr(
             r#"{"foo": 1}"#,
-            map(vec!{(s("foo"), Int(1))})
+            ast.map(&alist!{"foo" => ast.i(1)})
         );
 
         assert_expr(
             r#"{"foo": 1, "bar": 2}"#,
-            map(vec!{
-                (s("foo"), Int(1)),
-                (s("bar"), Int(2))
+            ast.map(&alist!{
+                "foo" => ast.i(1),
+                "bar" => ast.i(2)
             })
         );
     }
 
     #[test]
     fn test_terms() {
-        assert_expr("42", Int(42));
-        assert_expr("42.0", Float(42.0));
-        assert_expr("(42)", Int(42));
-        assert_expr("foo", id("foo"));
-        assert_expr("-42", Int(-42));
-        assert_expr("-42.0", Float(-42.0));
-        assert_expr("-x", un(Neg, id("x")));
-        assert_expr("- 42", un(Neg, Int(42)));
-        assert_expr("- 42.0", un(Neg, Float(42.0)));
-        assert_expr("-(42)", un(Neg, Int(42)));
+	let ast = Builder::new();
+        assert_expr("42", ast.i(42));
+        assert_expr("42.0", ast.f(42.0));
+        assert_expr("(42)", ast.i(42));
+        assert_expr("foo", ast.id("foo"));
+        assert_expr("-42", ast.i(-42));
+        assert_expr("-42.0", ast.f(-42.0));
+        assert_expr("-x", ast.un(Neg, ast.id("x")));
+        assert_expr("- 42", ast.un(Neg, ast.i(42)));
+        assert_expr("- 42.0", ast.un(Neg, ast.f(42.0)));
+        assert_expr("-(42)", ast.un(Neg, ast.i(42)));
     }
 
     #[test]
     fn test_relational() {
-        assert_expr("3 + 4 < 3 * 4", bin(
+	let ast = Builder::new();
+        assert_expr("3 + 4 < 3 * 4", ast.bin(
             Lt,
-            bin(Add, Int(3), Int(4)),
-            bin(Mul, Int(3), Int(4))
+            ast.bin(Add, ast.i(3), ast.i(4)),
+            ast.bin(Mul, ast.i(3), ast.i(4))
         ));
 
-        assert_expr("3 + 4 > 3 * 4", bin(
+        assert_expr("3 + 4 > 3 * 4", ast.bin(
             Gt,
-            bin(Add, Int(3), Int(4)),
-            bin(Mul, Int(3), Int(4))
+            ast.bin(Add, ast.i(3), ast.i(4)),
+            ast.bin(Mul, ast.i(3), ast.i(4))
         ));
 
-        assert_expr("3 + 4 <= 3 * 4", bin(
+        assert_expr("3 + 4 <= 3 * 4", ast.bin(
             Lte,
-            bin(Add, Int(3), Int(4)),
-            bin(Mul, Int(3), Int(4))
+            ast.bin(Add, ast.i(3), ast.i(4)),
+            ast.bin(Mul, ast.i(3), ast.i(4))
         ));
 
-        assert_expr("3 + 4 >= 3 * 4", bin(
+        assert_expr("3 + 4 >= 3 * 4", ast.bin(
             Gte,
-            bin(Add, Int(3), Int(4)),
-            bin(Mul, Int(3), Int(4))
+            ast.bin(Add, ast.i(3), ast.i(4)),
+            ast.bin(Mul, ast.i(3), ast.i(4))
         ));
 
-        assert_expr("3 + 4 == 3 * 4", bin(
+        assert_expr("3 + 4 == 3 * 4", ast.bin(
             Eq,
-            bin(Add, Int(3), Int(4)),
-            bin(Mul, Int(3), Int(4))
+            ast.bin(Add, ast.i(3), ast.i(4)),
+            ast.bin(Mul, ast.i(3), ast.i(4))
         ));
     }
 
     #[test]
     fn test_logic() {
+	let ast = Builder::new();
         assert_expr(
             "x >= lower and x <= upper",
-            bin(And,
-                bin(Gte, id("x"), id("lower")),
-                bin(Lte, id("x"), id("upper"))));
+            ast.bin(And,
+                ast.bin(Gte, ast.id("x"), ast.id("lower")),
+                ast.bin(Lte, ast.id("x"), ast.id("upper"))));
 
         assert_expr(
             "x >= 3 or x > 4 and x > 5",
-            bin(And,
-                bin(Or,
-                    bin(Gte, id("x"), Int(3)),
-                    bin(Gt, id("x"), Int(4))),
-                bin(Gt, id("x"), Int(5))));
+            ast.bin(And,
+                ast.bin(Or,
+                    ast.bin(Gte, ast.id("x"), ast.i(3)),
+                    ast.bin(Gt, ast.id("x"), ast.i(4))),
+                ast.bin(Gt, ast.id("x"), ast.i(5))));
 
         assert_expr(
             "x >= 3 or (x > 4 and x > 5)",
-            bin(Or,
-                bin(Gte, id("x"), Int(3)),
-                bin(And,
-                    bin(Gt, id("x"), Int(4)),
-                    bin(Gt, id("x"), Int(5)))));
+            ast.bin(Or,
+                ast.bin(Gte, ast.id("x"), ast.i(3)),
+                ast.bin(And,
+                    ast.bin(Gt, ast.id("x"), ast.i(4)),
+                    ast.bin(Gt, ast.id("x"), ast.i(5)))));
 
         assert_expr(
             "(x >= 3) or (x > 4 and x > 5)",
-            bin(Or,
-                bin(Gte, id("x"), Int(3)),
-                bin(And,
-                    bin(Gt, id("x"), Int(4)),
-                    bin(Gt, id("x"), Int(5)))));
+            ast.bin(Or,
+                ast.bin(Gte, ast.id("x"), ast.i(3)),
+                ast.bin(And,
+                    ast.bin(Gt, ast.id("x"), ast.i(4)),
+                    ast.bin(Gt, ast.id("x"), ast.i(5)))));
     }
 
     #[test]
     fn test_call() {
+	let ast = Builder::new();
+
         assert_expr(
             "foo(a + 3, a and b)",
-            call(
-                id("foo"),
-                vec! { bin(Add, id("a"), Int(3)), bin(And, id("a"), id("b")) }
+            ast.call(
+                ast.id("foo"),
+                &[
+		    ast.bin(Add, ast.id("a"), ast.i(3)),
+		    ast.bin(And, ast.id("a"), ast.id("b"))
+		]
             )
         );
 
         assert_expr(
             "x(a or b, y <= 3, y(-g(a * 7)))",
-            call(
-                id("x"),
-                vec! {
-                    bin(Or, id("a"), id("b")),
-                    bin(Lte, id("y"), Int(3)),
-                    call(
-                        id("y"),
-                        vec!{
-                            un(
+            ast.call(
+                ast.id("x"),
+                &[
+                    ast.bin(Or, ast.id("a"), ast.id("b")),
+                    ast.bin(Lte, ast.id("y"), ast.i(3)),
+                    ast.call(
+                        ast.id("y"),
+                        &[
+                            ast.un(
                                 Neg,
-                                call(
-                                    id("g"),
-                                    vec!{ bin(Mul, id("a"), Int(7)) }
+                                ast.call(
+                                    ast.id("g"),
+                                    &[ast.bin(Mul, ast.id("a"), ast.i(7))]
                                 )
                             )
-                        }
+                        ]
                     )
-                }
+                ]
             )
         );
     }
 
     #[test]
     fn test_dot() {
+	let ast = Builder::new();
         assert_expr(
             "foo.bar",
-            dot(id("foo"), "bar")
+            ast.dot(ast.id("foo"), "bar")
         );
 
         assert_expr(
             "foo.bar.baz",
-            dot(dot(id("foo"), "bar"), "baz")
+            ast.dot(ast.dot(ast.id("foo"), "bar"), "baz")
         );
 
         assert_expr(
             "foo.bar()",
-            call(dot(id("foo"), "bar"), vec! {})
+            ast.call(ast.dot(ast.id("foo"), "bar"), &[])
         );
     }
 
     #[test]
     fn test_index() {
+	let ast = Builder::new();
         assert_expr(
             "foo[0]",
-            index(id("foo"), Int(0))
+            ast.index(ast.id("foo"), ast.i(0))
         );
 
         assert_expr(
             "foo[bar]",
-            index(id("foo"), id("bar"))
+            ast.index(ast.id("foo"), ast.id("bar"))
         );
 
         assert_expr(
             "foo[3 + 10 * 5]",
-            index(id("foo"), bin(Add, Int(3), bin(Mul, Int(10), Int(5))))
+            ast.index(ast.id("foo"), ast.bin(Add, ast.i(3), ast.bin(Mul, ast.i(10), ast.i(5))))
         );
 
         assert_expr(
             "foo[3][4]",
-            index(index(id("foo"), Int(3)), Int(4))
+            ast.index(ast.index(ast.id("foo"), ast.i(3)), ast.i(4))
         );
 
         assert_expr(
             "foo[3].bar.baz[5][6]",
-            index(
-                index(
-                    dot(
-                        dot(
-                            index(id("foo"), Int(3)),
+            ast.index(
+                ast.index(
+                    ast.dot(
+                        ast.dot(
+                            ast.index(ast.id("foo"), ast.i(3)),
                             "bar"
                         ),
                         "baz"
                     ),
-                    Int(5)
+                    ast.i(5)
                 ),
-                Int(6)
+                ast.i(6)
             )
         );
 
@@ -272,64 +284,67 @@ mod tests {
 
         assert_expr(
             "(foo())[3]",
-            index(call(id("foo"), vec!{}), Int(3))
+            ast.index(ast.call(ast.id("foo"), &[]), ast.i(3))
         );
 
         assert_expr(
             "(foo()).bar",
-            dot(call(id("foo"), vec!{}), "bar")
+            ast.dot(ast.call(ast.id("foo"), &[]), "bar")
         );
     }
 
     #[test]
     fn test_simple_statement() {
-        assert_statement("out fill;", emit("fill", vec!{}));
+	let ast = Builder::new();
+        assert_statement("out fill;", ast.emit("fill", &[]));
         assert_statement(
             "out moveto x, y;",
-            emit("moveto", vec!{id("x"), id("y")})
+            ast.emit("moveto", &[ast.id("x"), ast.id("y")])
         );
 
         assert_statement(
             "let y = x * 3 + 4;",
-            def("y", bin(Add, bin(Mul, id("x"), Int(3)), Int(4)))
+            ast.def("y", ast.bin(Add, ast.bin(Mul, ast.id("x"), ast.i(3)), ast.i(4)))
         );
     }
 
     #[test]
     fn test_expr_block() {
-        assert_expr("{let x = y; yield 4}", expr_block(
-            vec!{def("x", id("y"))},
-            Int(4))
+	let ast = Builder::new();
+        assert_expr("{let x = y; yield 4}", ast.block(
+            &[ast.def("x", ast.id("y"))],
+            ast.i(4))
         );
 
-        assert_expr("{let x = frob(y); yield y * 4}", expr_block(
-            vec!{def("x", call(id("frob"), vec!{id("y")}))},
-            bin(Mul, id("y"), Int(4))
+        assert_expr("{let x = frob(y); yield y * 4}", ast.block(
+            &[ast.def("x", ast.call(ast.id("frob"), &[ast.id("y")]))],
+            ast.bin(Mul, ast.id("y"), ast.i(4))
         ));
 
-        assert_expr("{out debug x; yield x}", expr_block(
-            vec!{emit("debug", vec!{id("x")})},
-            id("x")
+        assert_expr("{out debug x; yield x}", ast.block(
+            &[ast.emit("debug", &[ast.id("x")])],
+            ast.id("x")
         ));
 
         assert_expr(
             "{let x = {let y = 2; yield y * 3}; yield x}",
-            expr_block(
-                vec!{
-                    def("x",
-                        expr_block(
-                            vec!{def("y", Int(2))},
-                            bin(Mul, id("y"), Int(3))
-                        )
+            ast.block(
+		&[
+                    ast.def("x",
+			    ast.block(
+				&[ast.def("y", ast.i(2))], 
+				ast.bin(Mul, ast.id("y"), ast.i(3))
+			    )
                     )
-                },
-                id("x")
-            )
-        );
+		],
+		ast.id("x")
+	    )
+	);
     }
 
     #[test]
     fn test_list_iter() {
+	let ast = Builder::new();
         let test = r#"
               for p in points {
                   out moveto p;
@@ -337,15 +352,25 @@ mod tests {
               }
         "#;
 
-        assert_statement(test, list_iter("p", id("points"), statement_block(vec!{
-            emit("moveto", vec!{id("p")}),
-            emit("circle", vec!{Float(50.0)})
-        })));
+	let parse = ast.list_iter(
+	    "p",
+	    ast.id("points"),
+	    ast.expr_for_effect(ast.block(
+		&[
+		    ast.emit("moveto", &[ast.id("p")]),
+		    ast.emit("circle", &[ast.f(50.0)])
+		],
+		ast.void.clone()
+	    ))
+        );
+
+        assert_statement(test, parse);
     }
 
 
     #[test]
     fn test_map_iter() {
+	let ast = Builder::new();
         let test = r#"
               for (k, v) in x {
                   out moveto v, v;
@@ -353,18 +378,35 @@ mod tests {
               }
         "#;
 
-        assert_statement(test, map_iter("k", "v", id("x"), statement_block(vec!{
-            emit("moveto", vec!{id("v"), id("v")}),
-            emit("text", vec!{id("k")})
-        })));
+	let parse = ast.map_iter(
+	    "k", "v",
+	    ast.id("x"),
+	    ast.expr_for_effect(ast.block(
+		&[
+		    ast.emit("moveto", &[ast.id("v"), ast.id("v")]),
+		    ast.emit("text", &[ast.id("k")])
+		],
+		ast.void.clone()
+	    ))
+	);
+
+        assert_statement(test, parse);
     }
 
     #[test]
     fn test_if() {
+	let ast = Builder::new();
         assert_statement(
             "if (a) { out text b; }",
-            guard(
-                vec!{(id("a"), emit("text", vec!{id("b")}))},
+            ast.guard(
+                &[(ast.id("a"),
+		   ast.block(
+		       &[
+			   ast.emit("text", &[ast.id("b")])
+		       ],
+		       ast.void.clone()
+		   ))
+		],
                 None
             )
         );
@@ -372,17 +414,24 @@ mod tests {
 
     #[test]
     fn test_if_else() {
+	let ast = Builder::new();
         assert_statement(
             r#"if (a) { out text b; } else { out text "error"; }"#,
-            guard(
-                vec!{(id("a"), emit("text", vec!{id("b")}))},
-                Some(emit("text", vec!{string("error")}))
+            ast.guard(
+                &[(ast.id("a"),
+		   ast.block(
+		       &[ast.emit("text", &[ast.id("b")])],
+		       ast.void.clone()
+		   ))
+		],
+                Some(ast.emit("text", &[ast.s("error")]))
             )
         );
     }
 
     #[test]
     fn test_if_elif_else() {
+	let ast = Builder::new();
         assert_statement(
             r#"if (a) {
                out text "a";
@@ -391,12 +440,12 @@ mod tests {
             } else {
                out text "error";
             }"#,
-            guard(
-                vec!{
-                    (id("a"), emit("text", vec!{string("a")})),
-                    (id("b"), emit("text", vec!{string("b")})),
-                },
-                Some(emit("text", vec!{string("error")}))
+            ast.guard(
+                &[
+                    (ast.id("a"), ast.block(&[ast.emit("text", &[ast.s("a")])], ast.void.clone())),
+                    (ast.id("b"), ast.block(&[ast.emit("text", &[ast.s("b")])], ast.void.clone())),
+                ],
+                Some(ast.emit("text", &[ast.s("error")]))
             )
         );
 
@@ -410,30 +459,31 @@ mod tests {
             } else {
                out text "error";
             }"#,
-            guard(
-                vec!{
-                    (id("a"), emit("text", vec!{string("a")})),
-                    (id("b"), emit("text", vec!{string("b")})),
-                    (id("c"), emit("text", vec!{string("c")})),
-                },
-                Some(emit("text", vec!{string("error")}))
+            ast.guard(
+                &[
+                    (ast.id("a"), ast.block(&[ast.emit("text", &[ast.s("a")])], ast.void.clone())),
+                    (ast.id("b"), ast.block(&[ast.emit("text", &[ast.s("b")])], ast.void.clone())),
+                    (ast.id("c"), ast.block(&[ast.emit("text", &[ast.s("c")])], ast.void.clone())),
+                ],
+                Some(ast.emit("text", &[ast.s("error")]))
             )
         );
     }
 
     #[test]
     fn test_if_elif() {
+	let ast = Builder::new();
         assert_statement(
             r#"if (a) {
                out text "a";
             } elif (b) {
                out text "b";
             }"#,
-            guard(
-                vec!{
-                    (id("a"), emit("text", vec!{string("a")})),
-                    (id("b"), emit("text", vec!{string("b")})),
-                },
+            ast.guard(
+                &[
+                    (ast.id("a"), ast.block(&[ast.emit("text", &[ast.s("a")])], ast.void.clone())),
+                    (ast.id("b"), ast.block(&[ast.emit("text", &[ast.s("b")])], ast.void.clone())),
+                ],
                 None
             )
         );
@@ -446,39 +496,30 @@ mod tests {
             } elif (c) {
                out text "c";
             }"#,
-            guard(
-                vec!{
-                    (id("a"), emit("text", vec!{string("a")})),
-                    (id("b"), emit("text", vec!{string("b")})),
-                    (id("c"), emit("text", vec!{string("c")})),
-                },
+            ast.guard(
+                &[
+                    (ast.id("a"), ast.block(&[ast.emit("text", &[ast.s("a")])], ast.void.clone())),
+                    (ast.id("b"), ast.block(&[ast.emit("text", &[ast.s("b")])], ast.void.clone())),
+                    (ast.id("c"), ast.block(&[ast.emit("text", &[ast.s("c")])], ast.void.clone())),
+                ],
                 None
             )
         );
     }
 
-    fn anon(statements: Vec<Statement>) -> Expr {
-        lambda(vec!{}, TypeTag::Void, expr_block(statements, Expr::Void))
-    }
-
-    fn tree(
-        func: Expr,
-        args: Vec<Expr>, trailing: Vec<Statement>
-    ) -> Statement {
-        let mut args = args;
-        args.push(anon(trailing));
-        expr_for_effect(call(func, args))
-    }
-
     #[test]
     fn test_tree_expr() {
-        assert_statement("foo();", expr_for_effect(
-            call(id("foo"), vec!{})
+	let ast = Builder::new();
+        assert_statement("foo();", ast.expr_for_effect(
+            ast.call(ast.id("foo"), &[])
         ));
 
         assert_statement(
             "foo() { out paint;}",
-            tree(id("foo"), vec!{}, vec!{emit("paint", vec!{})})
+            ast.template_call(ast.id("foo"), &[], ast.block(
+		&[ast.emit("paint", &[])],
+		ast.void.clone()
+	    ))
         );
 
         assert_statement(
@@ -491,69 +532,82 @@ mod tests {
                 frobulate();
             }
             "#,
-            tree(id("foo"), vec!{id("x")}, vec!{
-                tree(
-                    id("bar"),
-                    vec!{id("y"), id("z")},
-                    vec!{
-                        expr_for_effect(call(id("gronk"), vec!{})),
-                        expr_for_effect(call(id("frobulate"), vec!{}))
-                    }
-                ),
-                expr_for_effect(call(id("frobulate"), vec!{}))
-            })
+            ast.template_call(
+		ast.id("foo"),
+		&[ast.id("x")],
+		ast.block(
+		    &[
+			ast.template_call(
+			    ast.id("bar"),
+			    &[ast.id("y"), ast.id("z")],
+			    ast.block(
+				&[
+				    ast.expr_for_effect(ast.call(ast.id("gronk"), &[])),
+				    ast.expr_for_effect(ast.call(ast.id("frobulate"), &[]))
+				],
+				ast.void.clone()
+			    )
+			),
+			ast.expr_for_effect(ast.call(ast.id("frobulate"), &[]))
+		    ],
+		    ast.void.clone()
+		),
+	    )
         );
     }
 
     #[test]
     fn test_lambda_expr() {
+	let ast = Builder::new();
         assert_expr(
             "() = {}",
-            lambda(vec!{}, TypeTag::Void, map(vec!{}))
+            ast.lambda(&[], ast.t_void.clone(), ast.map(&[]))
         );
 
         assert_expr(
             "() = 4",
-            lambda(vec!{}, TypeTag::Void, Int(4))
+            ast.lambda(&[], ast.t_void.clone(), ast.i(4))
         );
 
 
         assert_expr(
             "() -> Int = 4",
-            lambda(vec!{}, TypeTag::Int, Int(4))
+            ast.lambda(&[], ast.t_int.clone(), ast.i(4))
         );
 
         assert_expr(
             "() = {let x = 4; yield x}",
-            lambda(
-                vec!{},
-                TypeTag::Void,
-                expr_block(
-                    vec!{def("x", Int(4))},
-                    id("x")
+            ast.lambda(
+		&[],
+                ast.t_void.clone(),
+                ast.block(
+                    &[ast.def("x", ast.i(4))],
+                    ast.id("x")
                 )
             )
         );
 
         assert_expr(
             "(x: Int, y: Int) -> Int = x * y",
-            lambda(
-                to_alist(vec!{
-		    (s("x"), TypeTag::Int),
-		    (s("y"), TypeTag::Int)
-		}),
-                TypeTag::Int,
-                bin(Mul, id("x"), id("y"))
-            )
+            ast.lambda(
+		&alist!{
+		    "x" => ast.t_int.clone(),
+		    "y" => ast.t_int.clone()
+		},
+                ast.t_int.clone(),
+                ast.bin(Mul, ast.id("x"), ast.id("y"))
+	    )
         );
 
         assert_expr(
             "(x: Int) -> Int = 4",
-            lambda(
-                to_alist(vec!{(s("x"), TypeTag::Int)}),
-                TypeTag::Int,
-                Int(4)
-            )
+            ast.lambda(
+                &alist!{
+		    "x" => ast.t_int.clone()
+		},
+                ast.t_int.clone(),
+                ast.i(4)
+	    )
         );
     }
 
@@ -561,63 +615,66 @@ mod tests {
     
     #[test]
     fn test_type_record_empty() {
+	let ast = Builder::new();
 	assert_type(
 	    r#"{}"#,
-	    TypeTag::Record(vec!{})
+	    ast.record(&[])
 	);
     }
 
     #[test]
     fn test_type_record_simple() {
+	let ast = Builder::new();
 	assert_type(
 	    r#"{field x: Int}"#,
-	    TypeTag::Record(
-		to_alist(vec!{(s("x"), Member::Field(Node::new(TypeTag::Int)))})
-	    )
+	    ast.record(&alist!{
+		"x" => Member::Field(ast.t_int.clone())
+	    })
 	);
     }
 
     #[test]
     fn test_type_record_complex() {
+	let ast = Builder::new();
+
 	let dist = Member::Method(
-	    to_alist(vec!{(s("other"), TypeTag::This)}),
-	    Node::new(TypeTag::Float),
-	    Node::new(expr_block(
-		vec!{
-		    def("dx", bin(Sub, dot(This, "x"), dot(id("other"), "x"))),
-		    def("dy", bin(Sub, dot(This, "y"), dot(id("other"), "y"))),
-		
-		},
-		call(
-		    id("sqrt"),
-		    vec!{
-			bin(Add,
-			    bin(Mul, id("dx"), id("dx")),
-			    bin(Mul, id("dy"), id("dy"))
+	    alist(&alist!{"other" => ast.t_this.clone()}.to_vec()),
+	    ast.t_float.clone(),
+	    ast.block(
+		&[
+		    ast.def("dx", ast.bin(Sub, ast.dot(ast.this.clone(), "x"), ast.dot(ast.id("other"), "x"))),
+		    ast.def("dy", ast.bin(Sub, ast.dot(ast.this.clone(), "y"), ast.dot(ast.id("other"), "y"))),
+		],
+		ast.call(
+		    ast.id("sqrt"),
+		    &[
+			ast.bin(Add,
+			    ast.bin(Mul, ast.id("dx"), ast.id("dx")),
+			    ast.bin(Mul, ast.id("dy"), ast.id("dy"))
 			)
-		    }
+		    ]
 		)
-	    ))
+	    )
 	);
     
 	let from_polar = Member::StaticMethod(
-	    to_alist(vec!{
-		(s("r"), TypeTag::Float),
-		(s("theta"), TypeTag::Float)}
-	    ),
-	    Node::new(TypeTag::This),
-	    Node::new(map(vec!{
-		(s("x"), bin(Mul, id("r"), call(id("cos"), vec! {id("theta")}))),
-		(s("y"), bin(Mul, id("r"), call(id("sin"), vec! {id("theta")})))
-	    }))
+	    alist(&alist!{
+		"r" => ast.t_float.clone(),
+		"theta" => ast.t_float.clone()
+	    }),
+	    ast.t_this.clone(),
+	    ast.map(&alist!{
+		"x" => ast.bin(Mul, ast.id("r"), ast.call(ast.id("cos"), &[ast.id("theta")])),
+		"y" => ast.bin(Mul, ast.id("r"), ast.call(ast.id("sin"), &[ast.id("theta")]))
+	    })
 	);
 
 	let origin = Member::StaticValue(
-	    Node::new(TypeTag::This),
-	    Node::new(map(vec!{
-		(s("x"), Float(0.0)),
-		(s("y"), Float(0.0))
-	    }))
+	    ast.t_this.clone(),
+	    ast.map(&alist!{
+		"x" => ast.f(0.0),
+		"y" => ast.f(0.0)
+	    })
 	);
 
 	// A plausible point or vector type.
@@ -633,21 +690,19 @@ mod tests {
                };
 
                static fromPolar(r: Float, theta: Float) -> Self = {
-                     x: r * cos(theta),
-                     y: r * sin(theta),
+                  x: r * cos(theta),
+                  y: r * sin(theta),
                };
  
                const origin: Self = {x: 0.0, y: 0.0};
             }"#,
-	    TypeTag::Record(
-		to_alist(vec!(
-		    (s("x"), Member::Field(Node::new(TypeTag::Float))),
-		    (s("y"), Member::Field(Node::new(TypeTag::Float))),
-		    (s("dist"), dist),
-		    (s("fromPolar"), from_polar),
-		    (s("origin"), origin)
-		))
-	    )
+	    ast.record(&alist!{
+		"x"         => Member::Field(ast.t_float.clone()),
+		"y"         => Member::Field(ast.t_float.clone()),
+		"dist"      => dist,
+		"fromPolar" => from_polar,
+		"origin"    => origin
+	    })
 	);
     }
 
@@ -655,14 +710,15 @@ mod tests {
 
     #[test]
     fn test_statement_function_def() {
+	let ast = Builder::new();
         assert_statement(
             r#"func foo(y: Int) -> Int {yield 4 * y}"#,
-            def(
+            ast.def(
                 "foo",
-                lambda(
-		    to_alist(vec!{(s("y"), TypeTag::Int)}),
-                    TypeTag::Int,
-                    bin(Mul, Int(4), id("y"))
+                ast.lambda(
+		    &alist!{"y" => ast.t_int.clone()},
+                    ast.t_int.clone(),
+                    ast.bin(Mul, ast.i(4), ast.id("y"))
 		)
             )
         );
@@ -671,12 +727,12 @@ mod tests {
             r#"proc foo(y: Int) {
                out paint;
             }"#,
-            def(
+            ast.def(
                 "foo",
-                lambda(
-                    to_alist(vec!{(s("y"), TypeTag::Int)}),
-                    TypeTag::Void,
-                    expr_block(vec!{emit("paint", vec!{})}, Expr::Void)
+                ast.lambda(
+                    &alist!{"y" => ast.t_int.clone()},
+                    ast.t_void.clone(),
+                    ast.block(&[ast.emit("paint", &[])], ast.void.clone())
                 )
             )
         );
@@ -684,17 +740,26 @@ mod tests {
 
     #[test]
     fn test_statement_type_def() {
+	let ast = Builder::new();
 	assert_statement(
 	    r#"type Foo: Int;"#,
-	    typedef("Foo", TypeTag::Int)
+	    ast.typedef("Foo", ast.t_int.clone())
 	);
     }
 
     #[test]
     fn test_statement_let() {
+	let ast = Builder::new();
 	assert_statement(
 	    r#"let dx = a.x - b.x;"#,
-	    ast::def("dx", bin(Sub, dot(id("a"), "x"), dot(id("b"), "x")))
+	    ast.def(
+		"dx",
+		ast.bin(
+		    Sub,
+		    ast.dot(ast.id("a"), "x"),
+		    ast.dot(ast.id("b"), "x")
+		)
+	    )
 	);
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,22 +31,25 @@ mod tests {
     // Helper functions for test cases.
 
     fn assert_expr(text: &'static str, ast: ast::SubExpr) {
+	let builder = ast::Builder::new();
         assert_eq!(
-            Node::new(grammar::ExprParser::new().parse(text).unwrap()),
+            Node::new(grammar::ExprParser::new().parse(&builder, text).unwrap()),
             ast
         );
     }
 
     fn assert_statement(text: &'static str, ast: Node<Statement>) {
+	let builder = ast::Builder::new();
         assert_eq!(
-            Node::new(grammar::StatementParser::new().parse(text).unwrap()),
+            Node::new(grammar::StatementParser::new().parse(&builder, text).unwrap()),
             ast
         );
     }
 
     fn assert_type(text: &'static str, ast: ast::Node<TypeTag>) {
+	let builder = ast::Builder::new();
         assert_eq!(
-	    Node::new(grammar::TypeParser::new().parse(text).unwrap()),
+	    Node::new(grammar::TypeParser::new().parse(&builder, text).unwrap()),
             ast
         );
     }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -387,30 +387,11 @@ impl TypeChecker {
 mod tests {
     use super::*;
     #[allow(unused_imports)]
+    #[macro_use]
     use crate::ast;
     #[allow(unused_imports)]
+    #[macro_use]
     use crate::ast::*;
-
-    // Associative list macro, to go along with vec!
-    //
-    // Actually it really constructs an associative list, and then
-    // `collect()`s it.
-    macro_rules! alist(
-        { $($key:expr => $value:expr),* } => {
-            [ $( ($key, $value)),* ]
-        }
-    );
-
-    
-    // Construct containers from an alist
-    //
-    // Actually it really constructs an associative list, and then
-    // `collect()`s it.
-    macro_rules! map(
-        { $($key:expr => $value:expr),* } => {
-            [ $( ($key.to_string(), $value)),* ].iter().cloned().collect()
-        }
-    );
 
     // Assert that expr evaluated in env has type t.
     fn assert_types_to(env: Env<TypeTag>, expr: &Expr, t: &TypeExpr) {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -172,7 +172,7 @@ impl TypeChecker {
 
     pub fn eval_cond(
         &self,
-        cases: &Seq<(Expr, Expr)>,
+        cases: &PairSeq<Expr>,
         default: &Node<Expr>
     ) -> TypeExpr {
         let conds: Result<Seq<TypeTag>, TypeError> = cases

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -292,8 +292,10 @@ impl TypeChecker {
         let result = self.eval_expr(expr)?;
         match result.deref() {
             TypeTag::Map(item_type) => Ok(item_type.clone()),
-	    TypeTag::MapExpr(items) => Ok(Self::narrow(map_to_seq(items))),
-            _                       => Err(NotIterable(result))
+	    TypeTag::MapExpr(items) => Ok(Self::narrow(
+		items.values().cloned().collect())
+	    ),
+	    _                       => Err(NotIterable(result))
         }
     }
 


### PR DESCRIPTION
A concise API for the AST module, which simplifies both the parser and tests.

It took a while to hit on the right pattern, but I think this works quite well and is much cleaner than how I had it originally.

Closes #11