### PR TITLE
[MVP] Allow leading '|' in type unions

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -37,15 +37,20 @@ pub Expr: ExprNode = {
 
 
 // Type Entry Point
-pub Type: TypeNode = TypeExpr;
+pub Type: TypeNode = TypeMaybe;
 
 
-// Syntactic sugar for Union(a, b)
-pub TypeExpr: TypeNode = {
-    <a:TypeExpr> "|" <b:TypeCons> => ast.union(&[a, b]),
+// Maybe type Union(a, b)
+pub TypeMaybe: TypeNode = {
     // If we had a Sum type, it would go here, and would look like this.
     // <a:TypeExpr> "+" <b:TypeCons> => ast.sum(&[a, b]),
-    <TypeCons>   "?"              => ast.option(<>),
+    <TypeUnion>   "?"              => ast.option(<>),
+    TypeUnion,
+}
+
+pub TypeUnion: TypeNode = {
+    "|" <TypeUnion> => <>,
+    <a:TypeCons> "|" <b:TypeUnion> => ast.union(&[a, b]),
     TypeCons,
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -709,6 +709,109 @@ mod tests {
 	);
     }
 
+
+    #[test]
+    fn test_type_union() {
+	let ast = Builder::new();
+
+	assert_type(
+	    r#"Int | Float"#,
+	    ast.union(&[ast.t_int.clone(), ast.t_float.clone()])
+	);
+
+	assert_type(
+	    r#"| Int"#,
+	    ast.t_int.clone()
+	);
+
+	assert_type(
+	    r#"| Int | Float"#,
+	    ast.union(&[ast.t_int.clone(), ast.t_float.clone()])
+	);
+
+	assert_type(
+	    r#"Int | Float | Str"#,
+	    ast.union(&[ast.t_int.clone(), ast.union(&[
+		ast.t_float.clone(),
+		ast.t_str.clone()
+	    ])])
+	);
+
+	assert_type(
+	    r#"| Int | Float | Str"#,
+	    ast.union(&[ast.t_int.clone(), ast.union(&[
+		ast.t_float.clone(),
+		ast.t_str.clone()
+	    ])])
+	);
+
+	assert_type(
+	    r#"| Int | [Int] | Str"#,
+	    ast.union(&[ast.t_int.clone(), ast.union(&[
+		ast.t_list(ast.t_int.clone()),
+		ast.t_str.clone()
+	    ])])
+	); 
+
+	assert_type(
+	    r#"[Int | [Int] | Str]"#,
+	    ast.t_list(
+		ast.union(&[ast.t_int.clone(), ast.union(&[
+		    ast.t_list(ast.t_int.clone()),
+		    ast.t_str.clone()
+		])])
+	    )
+	);
+
+	assert_type(
+	    r#"[| Int | [Int] | Str]"#,
+	    ast.t_list(
+		ast.union(&[ast.t_int.clone(), ast.union(&[
+		    ast.t_list(ast.t_int.clone()),
+		    ast.t_str.clone()
+		])])
+	    )
+	);
+
+	assert_type(
+	    r#"| [| Int | [Int] | Str]"#,
+	    ast.t_list(
+		ast.union(&[ast.t_int.clone(), ast.union(&[
+		    ast.t_list(ast.t_int.clone()),
+		    ast.t_str.clone()
+		])])
+	    )
+	);
+
+	assert_type(
+	    r#"| [| Int | [Int] | Str] | Bool"#,
+	    ast.union(&[
+		ast.t_list(ast.union(&[
+		    ast.t_int.clone(),
+		    ast.union(&[
+			ast.t_list(ast.t_int.clone()),
+			ast.t_str.clone()
+		    ])])
+		),
+		ast.t_bool.clone()
+	    ])
+	);
+
+	assert_type(
+	    r#"| Int | [Int] | Str | Bool"#,
+	    ast.union(&[
+		ast.t_int.clone(),
+		ast.union(&[
+		    ast.t_list(ast.t_int.clone()),
+		    ast.union(&[
+			ast.t_str.clone(),
+			ast.t_bool.clone()
+		    ])
+		])
+	    ])
+	);
+    }
+
     // Test parsing of Statements.
 
     #[test]


### PR DESCRIPTION
Closes #23