### PR TITLE
IR Compiler for MVP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "LGPL-3.0-or-later"
 [dependencies]
 lalrpop-util = "0.18.1"
 ordered-float = "2.0"
+serde-json = "1.0"
 
 
 [build-dependencies.lalrpop]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "LGPL-3.0-or-later"
 
 [dependencies]
 lalrpop-util = "0.18.1"
-eq-float = "0.1.0"
+ordered-float = "2.0"
 
 
 [build-dependencies.lalrpop]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ license = "LGPL-3.0-or-later"
 
 [dependencies]
 lalrpop-util = "0.18.1"
+eq-float = "0.1.0"
+
 
 [build-dependencies.lalrpop]
 features = ["lexer"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "LGPL-3.0-or-later"
 [dependencies]
 lalrpop-util = "0.18.1"
 ordered-float = "2.0"
-serde-json = "1.0"
 
 
 [build-dependencies.lalrpop]

--- a/examples/count.us
+++ b/examples/count.us
@@ -1,0 +1,16 @@
+#! udlang
+
+version 0.1-pre_mvp;
+script "Count Example";
+
+input  Int;
+output Int;
+
+proc count(n: Int) {
+  out n;
+  if (n > 0) {
+    count(n - 1);
+  }
+}
+
+out count(in);

--- a/examples/fact.us
+++ b/examples/fact.us
@@ -1,0 +1,17 @@
+#! udlang
+
+version 0.1-pre_mvp;
+script "Factorial Example";
+
+input  Int;
+output Int;
+
+func fact(n: Int) -> Int {
+  if (n > 1) {
+    n * fact(n - 1)
+  } else {
+    n
+  }
+}
+
+out fact(in);

--- a/examples/function.us
+++ b/examples/function.us
@@ -7,7 +7,7 @@ input  Int;
 output Int;
 
 func celcius_to_farenheit(c: Float) -> Float {
-     9.0 * c / 5.0 + 32
+     9.0 * c / 5.0 + 32.0
 }
 
 out celcius_to_farenheit(in);

--- a/examples/function.us
+++ b/examples/function.us
@@ -1,0 +1,13 @@
+#! udlang
+
+version 0.1-pre_mvp;
+script "Function Example";
+
+input  Int;
+output Int;
+
+func celcius_to_farenheit(c: Float) -> Float {
+     9.0 * c / 5.0 + 32
+}
+
+out celcius_to_farenheit(in);

--- a/examples/hello.us
+++ b/examples/hello.us
@@ -1,0 +1,9 @@
+#! udlang
+
+version 0.1-pre_mvp;
+script "Hello world, in uDLang";
+
+input  Str;
+output Str;
+
+out "Hello, " + in;

--- a/examples/lists.us
+++ b/examples/lists.us
@@ -1,0 +1,15 @@
+#! udlang
+
+version 0.1-pre_mvp;
+script "List Example";
+
+let foo = [1, 2, 3, 4, 5];
+
+input  Int;
+output Int;
+
+func square(x: Int) -> Int {x * x}
+
+for x in foo {
+   out square(x) + in;
+}

--- a/examples/loop.us
+++ b/examples/loop.us
@@ -1,0 +1,17 @@
+#! udlang
+
+version 0.1-pre_mvp;
+script "Function Example";
+
+let data = [1.0, 2.0, 3.0];
+
+input  Int;
+output Int;
+
+func celcius_to_farenheit(c: Float) -> Float {
+     9.0 * c / 5.0 + 32.0
+}
+
+for datum in data {
+   out celcius_to_farenheit(datum);
+}

--- a/examples/scopes.us
+++ b/examples/scopes.us
@@ -1,0 +1,29 @@
+#! udlang
+
+version 0.1-pre_mvp;
+script "Scope Example";
+
+input  Int;
+output Int;
+
+// This value should be captured.
+let x = 2;
+let y = 0;
+let z = 0;
+
+proc test(z: Int) {
+  let y = 3;
+  {
+    out x * y + z;
+  }
+}
+
+test(1); // should output 7.
+
+func addn(n: Int) -> ((n: Int) -> Int) {
+  (x: Int) -> Int {x + n}
+}
+
+let add1 = addn(1);
+
+out add1(10); // Should output 11.

--- a/examples/simple.us
+++ b/examples/simple.us
@@ -1,0 +1,17 @@
+#! udlang
+
+version 0.1-pre_mvp;
+script "Function calls";
+
+input  Int;
+output Int;
+
+func bar(c: Float) -> Float {
+    c - 1.0
+}
+
+func foo(c: Float) -> Float {
+     2.0 * bar(c)
+}
+
+out foo(in);

--- a/examples/subjunctive.us
+++ b/examples/subjunctive.us
@@ -1,0 +1,25 @@
+#! udlang
+
+version 0.1-pre_mvp;
+script "Subjunctive Example";
+
+
+input  Bool;
+output Str;
+
+
+proc she_loves_you(love_is_real: Bool) {
+   if (love_is_real) {
+      out "Yeah! ";
+   }
+}
+
+
+suppose(she_loves_you(in)) {
+  out "She loves you, ";
+  ...;
+  ...;
+  ...;
+} else {
+  out "Yesterdayyyyyyyy";
+}

--- a/scripts/stackfolder.py
+++ b/scripts/stackfolder.py
@@ -1,0 +1,532 @@
+#! python3
+
+## Python prototype of stack-folding optimizer for "self-optimizing" stack
+## code.
+##
+## Defines a toy stack language, roughly isomorphic to uDLang, including:
+##
+## - toy instruction set
+## - toy VM implementation
+## - toy const-fold / inlining optimizer
+##
+## The goal here is to prove out the concept of optimizing stack-based IR
+## through a custom VM.
+
+# Define our instruction set.
+#
+# Each instruction either an `Instruction` instance, or a function returning an
+# `Instruction` instance.
+#
+# The lambda given to `Instruction` computes the instruction result, where:
+# - vm: is a vm instance
+# -  v: is an argument vector of apropriate length
+#
+# The functions called on `vm` by this instruction set constitutes the VM
+# interface, so different passes can process the VMs.
+class Instruction:
+
+    def __init__(self, name, args, func, *meta):
+        self.name = name
+        self.args = args
+        self.func = func
+        self.meta = meta
+
+    def __repr__(self):
+        if len(self.meta):
+            return "%s(%s)" % (self.name, ", ".join(repr(r) for r in self.meta))
+        else:
+            return self.name
+
+# Define a variable for each instruction.
+const = lambda value: Instruction("const",      0, lambda vm, v: value,                  value)
+load  = lambda id:    Instruction("load",       0, lambda vm, v: vm.load(id),               id)
+store = lambda id:    Instruction("store",      1, lambda vm, v: vm.store(id, v[0]),        id)
+call  = lambda n:     Instruction("call",   n + 1, lambda vm, v: vm.call_always(n, v),       n)
+if_   = lambda n:     Instruction("if",     n + 2, lambda vm, v: vm.call_if(n, v),           n)
+ife   = lambda n:     Instruction("ifelse", n + 3, lambda vm, v: vm.call_ifelse(n, v),       n)
+# each= lambda n:     Instruction("each",   n + 1, lambda vm, v: vm.call_foreach(n, v),      n)
+add   =               Instruction("add",        2, lambda vm, v: v[0] + v[1])
+sub   =               Instruction("sub",        2, lambda vm, v: v[0] - v[1])
+mul   =               Instruction("mul",        2, lambda vm, v: v[0] * v[1])
+div   =               Instruction("div",        2, lambda vm, v: v[0] / v[1])
+lt    =               Instruction("lt",         2, lambda vm, v: v[0] < v[1])
+gte   =               Instruction("gte",        2, lambda vm, v: v[0] >= v[1])
+out   =               Instruction("out",        1, lambda vm, v: vm.out(v[0]))
+inp   =               Instruction("inp",        0, lambda vm, v: vm.input())
+
+
+# Represents a function value in our stack language.
+#
+# - args: [str],         argument names
+# - code: [Instruction], function body
+# - name: str?,          optional name for recursive functions.
+class Fun:
+    def __init__(self, args, code, name=None):
+        self.name = name
+        self.args = args
+        self.code = code
+
+    # XXX: it would be better to do some minimal analysis to determine if we
+    # are actually recursive.
+    def is_recursive(self):
+        return self.name is not None
+
+    def __repr__(self):
+        args = ", ".join(repr(r) for r in self.args) if self.args else ""
+        code = " ".join(repr(r) for r in self.code)
+        head = "fn %s" % self.name if self.is_recursive() else "fn"
+        params = " (%s) " % args if args else " "
+        return head + params + "[%s]" % code
+
+
+# Recursive chain of local values.
+#
+# - parent: Scope?, optional parent scope.
+class Scope:
+
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.locals = {}
+        self.depth = parent.depth + 1 if parent else 0
+
+    def load(self, name):
+        if name in self.locals:
+            return self.locals[name]
+        else:
+            if self.parent:
+                return self.parent.load(name)
+            else:
+                raise ValueError("%s is undefined" % name)
+
+    def store(self, name, value):
+        self.locals[name] = value
+
+    def __repr__(self):
+        return repr(self.locals)
+
+
+## Example programs using this instruction set.
+
+# The usual recursive factorial. Demonstrates that recursion doesn't break the
+# optimizer.
+fact = [
+    const(Fun(["n"], [
+        load("n"),
+        const(2),
+        gte,
+        const(Fun([], [
+            load("n"),
+            const(1),
+            sub,
+            load("fact"),
+            call(1),
+            load("n"),
+            mul
+        ])),
+        const(Fun([], [const(1)])),
+        ife(0)
+    ], "fact")), # NOTE: function name provided here to enable recursion.
+    # This store will be optimized out entirely.
+    store('fact'),
+
+    # This call should optimize out, since arg is const.
+    const(10),
+    load('fact'),
+    call(1),
+    out,
+
+    # This call will not be optimized at all, because arg is non-const, and
+    # `fact` is recursive.
+    inp,
+    load('fact'),
+    call(1),
+    out
+]
+
+
+# Here's example which will benefit from stack-folding.
+#
+# This sequence of calls is not recursive, so it should always optimize fully.
+linear = [
+    # define a general linear function
+    const(Fun(["slope", "intercept", "x"], [
+        load("x"),
+        load("slope"),
+        mul,
+        load("intercept"),
+        add
+    ])),
+    store("linear"),
+
+    # convert celcius to farenheit, using linear
+    const(Fun(["t"], [
+        const(9.0),
+        const(5.0),
+        div,
+        const(32.0),
+        load("t"),
+        load("linear"),
+        call(3)
+    ])),
+    store("c2f"),
+
+    # call c2f on a constant. Under optimization, call will be optimized out.
+    const(100.0),
+    load("c2f"),
+    call(1),
+    out,
+
+    # call c2f on the input record. Under optimization, call will be inlined
+    # here.
+    inp,
+    load("c2f"),
+    call(1),
+    out
+]
+
+
+# Here's an example which demonstrates optimized nesting closure calls.
+#
+# should print A(B(CD))
+#
+# tree("A", fn {tree("B", fn (){ out "C"; out "D"})})
+#
+# All of the calls should be optimized out, leading to a linear sequence of out
+# instructions.
+tree = [
+    # define a tree template function
+    const(Fun(["name", "contents"], [
+        load("name"), out,
+        const("("),   out,
+        load("contents"), call(0),
+        const(")"),   out
+    ])),
+    store("tree"),
+
+    const("A"),
+    const(Fun([], [
+        const("B"),
+        const(Fun([], [
+            const("C"),
+            out,
+            const("D"),
+            out
+        ])),
+        load("tree"),
+        call(2)
+    ])),
+    load("tree"),
+    call(2)
+]
+
+
+# Another tree example
+#
+# should print A(B(A(CD), B(CD)))
+#
+# func a (arg) {tree("A", arg)}
+# func b (arg) {tree("B", arg)}
+# func cd ()   {out "C"; out "D";}
+# a(fn { b(cd); a(cd)})
+          
+tree2 = [
+    # define a tree template function
+    const(Fun(["name", "contents"], [
+        load("name"), out,
+        const("("),   out,
+        load("contents"), call(0),
+        const(")"),   out
+    ])),
+
+    store("tree"),
+
+    const(Fun(["arg"], [const("A"), load("arg"), load("tree"), call(2)])),
+    store("a"),
+    
+    const(Fun(["arg"], [const("B"), load("arg"), load("tree"), call(2)])),
+    store("b"),
+
+    const(Fun([], [const("C"), out, const("D"), out])),
+    store("cd"),
+
+    const(Fun([], [
+        const(Fun([], [
+            load("cd"),
+            load("a"),
+            call(1),
+
+            load("cd"),
+            load("b"),
+            call(1)
+        ])),
+        load("b"),
+        call(1)
+    ])),
+    load("a"),
+    call(1)
+]
+
+
+# Naive stack VM for this instruction set.
+#
+# This is trivially correct, and used to validate that the optimizer works as
+# expected. Also, it is used to execute optimized code.
+class VM(object):
+
+    def __init__(self, input_record, parent=None):
+        self.locals = Scope(parent)
+        self.stack = []
+        self.input_record = input_record
+
+    def debug_trace(self, i, code):
+        return (
+            ("locals", self.locals),
+            ("stack", self.stack)
+        )
+
+    def trace_start(self, i, code):
+        indent = "  " * self.locals.depth
+        print(indent, "begin:", code[i])
+        for (k, v) in self.debug_trace(i, code):
+            print(indent, k + ":", v)
+
+    def trace_end(self, i, code):
+        indent = "  " * self.locals.depth
+        print(indent, "end:", code[i])
+        for (k, v) in self.debug_trace(i, code):
+            print(indent, k + ":", v)
+
+    def nested(self, frame):
+        return VM(self.input_record, frame)
+
+    def input(self):
+        self.push(self.input_record)
+
+    def push(self, value):
+        self.stack.append(value)
+
+    def pop(self):
+        return self.stack.pop()
+
+    def load(self, name):
+        self.push(self.locals.load(name))
+
+    def store(self, name, value, is_arg=False):
+        self.locals.store(name, value)
+
+    def get_operands(self, n):
+        if n > 0:
+            ret = self.stack[-n:]
+            self.stack = self.stack[:-n]
+            return ret
+        else:
+            return []
+
+    def out(self, value):
+        print("out: ", value)
+
+    def eval(self, code):
+        for (i, instruction) in enumerate(code):
+            self.trace_start(i, code)
+            self.eval_instruction(
+                instruction,
+                self.get_operands(instruction.args))
+            self.trace_end(i, code)
+            print()
+
+    def eval_instruction(self, instruction, operands):
+        result = instruction.func(self, operands)
+        if result is not None:
+            self.push(result)
+
+    def call_always(self, n, args):
+        self.call(n, args[:-1], args[-1])
+
+    def call_if(self, n, args):
+        func = args[-1]
+        cond = args[-2]
+        if cond:
+            self.call(n, args[:-2], func)
+
+    def call_ifelse(self, n, args):
+        cond = args[-3]
+        func = args[-2] if cond else args[-1]
+        self.call(n, args[:-3], func)
+
+    def call(self, n, args, func):
+        assert(n == len(args) == len(func.args))
+        args = zip(func.args, args)
+        scope = Scope(self.locals)
+
+        if func.is_recursive():
+            self.store(func.name, func, is_arg=True)
+
+        for (name, value) in args:
+            self.store(name, value, is_arg=True)
+
+        nested = self.nested(scope)
+        nested.eval(func.code)
+
+        if len(nested.stack) == 0:
+            pass
+        elif len(nested.stack) == 1:
+            self.push(nested.stack[0])
+        else:
+            raise ValueError("Function returned multiple values")
+
+        return nested
+
+
+## Optimizer prototype
+
+
+# A value representing a deferred instruction.
+#
+# A.k.a. a thunk.
+#
+# Operations on non-const return these.
+class Defer:
+    def __init__(self, instruction, operands):
+        self.instruction = instruction
+        self.operands = operands
+
+    def __repr__(self):
+        return "Def(%s, %s)" % (self.instruction, self.operands)
+
+
+# The optimizer is a specialized stack machine that is aware of Defer values.
+#
+# Execution happens eagerly until an `inp` or `out` instruction is reached.
+# `inp` places `Defer(inp, [])` onto the stack, causing subsequent instructions
+# to fold into the Defer.
+#
+# `out` triggers code generation
+# - if operand is a value, then it's lifted to a const() value
+# - if operand is Defer, then it's flattened into the output.
+#
+# For this toy example, only code producing output will be present after
+# optimization, and expression depending only on constant values will be
+# const-folded.
+#
+# For the real interpreter, we would also want to emit code for exported
+# functions when optimizing a library module. But this exploration is really
+# just trying to define the essence of the stack-folding optimizer.
+class Optimizer(VM):
+
+    def __init__(self, scope=None):
+        # create a vm, but give a thunk for the input record
+        VM.__init__(self, Defer(inp, []), scope)
+        self.output = []
+
+    # override debug_trace: append our incremental generated code.
+    def debug_trace(self, i, code):
+        return VM.debug_trace(self, i, code) + (("output", self.output),)
+
+    # override nested: return Optimizer instead of VM.
+    def nested(self, scope):
+        return Optimizer(scope)
+
+    # override call_if: if cond is deferred, defer the conditional.
+    def call_if(self, n, args):
+        if isinstance(args[-2], Defer):
+            self.push(Defer(if_(n), args))
+        else:
+            VM.call_if(self, n, args)
+
+    # override call_ifelse: if cond is deferred, defer the conditional.
+    def call_ifelse(self, n, args):
+        if isinstance(args[-3], Defer):
+            self.push(Defer(ife(n), args))
+        else:
+            VM.call_ifelse(self, n, args)
+
+    # override call:
+    # - if func is deferred, defer the call.
+    # - if func is recursive, and any arguments are deferred, defer the call.
+    def call(self, n, args, func):
+        if isinstance(func, Defer):
+            # if the function value is not static, we must push a
+            # thunk representing the entire call.
+            self.push(Defer(call(n), args + [func]))
+        elif func.is_recursive() and any(isinstance(arg, Defer) for arg in args):
+            self.push(Defer(call(n), args + [func]))
+        else:
+            # Otherwise we can try to call the function. If any arguments given
+            # were thunks, then we'll get a thunk result on the stack when
+            # eval_token tries to operate on it.
+            nested = VM.call(self, n, args, func)
+            self.output.extend(nested.output)
+
+    # override out: generate optimized code to yield the output.
+    def out(self, value):
+        self.emit(value)
+        self.emit(out)
+
+    # override eval_instruction:
+    # defer any arithmetic / logic operations on thunks.
+    overrides = {"call", "out", "store", "ifelse", "if"}
+    def eval_instruction(self, instruction, operands):
+        if instruction.name in self.overrides:
+            VM.eval_instruction(self, instruction, operands)
+        elif any(isinstance(op, Defer) for op in operands):
+            # we can't execute, so we push a thunk representing the computation.
+            self.push(Defer(instruction, operands))
+        else:
+            VM.eval_instruction(self, instruction, operands)
+
+    # place optimized instructions into the output.
+    def emit(self, value):
+        if isinstance(value, Defer):
+            # recursively flatten thunks into the output.
+            for operand in value.operands:
+                self.emit(operand)
+            self.output.append(value.instruction)
+        elif isinstance(value, Instruction):
+            # instructions pass through as is
+            self.output.append(value)
+        else:
+            # Lift constant values to const instructions.
+            self.output.append(const(value))
+
+
+# should print 3628800
+vm = VM(10)
+vm.eval(fact)
+
+# Prints: 212.0, 32.0
+# So far so good.
+vm = VM(0.0)
+vm.eval(linear)
+
+vm = VM(None)
+vm.eval(tree)
+
+opt = Optimizer()
+opt.eval(tree)
+print("Optimizer output")
+for insn in opt.output:
+    print(insn)
+vm = VM(None)
+vm.eval(opt.output)
+
+opt = Optimizer()
+opt.eval(tree2)
+print("Optimizer output")
+for insn in opt.output:
+    print(insn)
+
+opt = Optimizer()
+opt.eval(linear)
+print("Optimizer output")
+for insn in opt.output:
+    print(insn)
+vm = VM(0.0)
+vm.eval(opt.output)
+
+opt = Optimizer()
+opt.eval(fact)
+print("Optimizer output")
+for insn in opt.output:
+    print(insn)
+vm = VM(10)
+vm.eval(opt.output)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::ops::Deref;
+use std::hash::Hash;
 
 
 // Associative list macro for slices of named pairs with python-like
@@ -126,7 +127,7 @@ pub type MemberNode = Node<Member>;
 // transformations.
 
 // Arithmetic and logic operations
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum BinOp {
     Add,
     Sub,
@@ -149,7 +150,7 @@ pub enum BinOp {
 }
 
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum UnOp {
     Not,
     Neg,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -108,7 +108,7 @@ pub type ExprNode = Node<Expr>;
 pub type TypeNode = Node<TypeTag>;
 pub type StmtNode = Node<Statement>;
 pub type MemberNode = Node<Member>;
-
+pub type Float = eq_float::F64;
 
 // *** ADT ********************************************************************
 
@@ -219,9 +219,9 @@ pub enum Expr {
     Void,
     Bool(bool),
     Int(i64),
-    Float(f64),
+    Float(Float),
     Str(String),
-    Point(f64, f64),
+    Point(Float, Float),
     This, // the lowercase `self` keyword, but we can't call it that.
     In, // The `in` keyword.
     Partial, // The `$` placeholder.
@@ -417,14 +417,14 @@ impl Builder {
     }
 
     pub fn f(&self, value: f64) -> ExprNode {
-	self.subexpr(Expr::Float(value))
+	self.subexpr(Expr::Float(value.into()))
     }
 
     pub fn s(&self, value: &str) -> ExprNode {
 	self.subexpr(Expr::Str(String::from(value)))
     }
 
-    pub fn point(&self, x: f64, y: f64) -> ExprNode {
+    pub fn point(&self, x: Float, y: Float) -> ExprNode {
 	self.subexpr(Expr::Point(x, y))
     }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -256,7 +256,7 @@ pub enum Statement {
     ListIter(String, ExprNode, ExprNode),
     MapIter(String, String, ExprNode, ExprNode),
     While(ExprNode, StmtNode),
-    Suppose(ExprNode, StmtNode, StmtNode),
+    Suppose(ExprNode, ExprNode, ExprNode),
     EffectCapture,
 }
 
@@ -474,8 +474,8 @@ impl Builder {
     pub fn suppose(
 	&self,
 	delegate: ExprNode,
-	branch: StmtNode,
-	leaf: StmtNode
+	branch: ExprNode,
+	leaf: ExprNode
     ) -> StmtNode {
 	self.statement(Statement::Suppose(delegate, branch, leaf))
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -253,8 +253,8 @@ pub enum Statement {
     Out(ExprNode),
     Def(String, ExprNode),
     TypeDef(String, TypeNode),
-    ListIter(String, ExprNode, StmtNode),
-    MapIter(String, String, ExprNode, StmtNode),
+    ListIter(String, ExprNode, ExprNode),
+    MapIter(String, String, ExprNode, ExprNode),
     While(ExprNode, StmtNode),
     Suppose(ExprNode, StmtNode, StmtNode),
     EffectCapture,
@@ -680,7 +680,7 @@ impl Builder {
     pub fn list_iter(
 	&self,
 	name: &str, list: ExprNode,
-	body: StmtNode
+	body: ExprNode
     ) -> StmtNode {
 	self.statement(
 	    Statement::ListIter(
@@ -696,7 +696,7 @@ impl Builder {
 	key: &str,
 	value: &str,
 	map: ExprNode,
-	body: StmtNode
+	body: ExprNode
     ) -> StmtNode {
 	self.statement(Statement::MapIter(
             String::from(key),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -255,7 +255,6 @@ pub enum Statement {
     TypeDef(String, TypeNode),
     ListIter(String, ExprNode, ExprNode),
     MapIter(String, String, ExprNode, ExprNode),
-    While(ExprNode, StmtNode),
     Suppose(ExprNode, ExprNode, ExprNode),
     EffectCapture,
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,5 @@
+// (C) 2021 Brandon Lewis
+
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -108,7 +110,7 @@ pub type ExprNode = Node<Expr>;
 pub type TypeNode = Node<TypeTag>;
 pub type StmtNode = Node<Statement>;
 pub type MemberNode = Node<Member>;
-pub type Float = eq_float::F64;
+pub type Float = ordered_float::OrderedFloat<f64>;
 
 // *** ADT ********************************************************************
 
@@ -128,6 +130,7 @@ pub type Float = eq_float::F64;
 
 // Arithmetic and logic operations
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
 pub enum BinOp {
     Add,
     Sub,
@@ -151,6 +154,7 @@ pub enum BinOp {
 
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
 pub enum UnOp {
     Not,
     Neg,
@@ -246,7 +250,7 @@ pub enum Statement {
     Import(Import),
     Export(Export),
     ExprForEffect(ExprNode),
-    Emit(ExprNode),
+    Out(ExprNode),
     Def(String, ExprNode),
     TypeDef(String, TypeNode),
     ListIter(String, ExprNode, StmtNode),
@@ -643,8 +647,8 @@ impl Builder {
 	}
     }
 
-    pub fn emit(&self, expr: ExprNode) -> StmtNode {
-	self.statement(Statement::Emit(expr))
+    pub fn out(&self, expr: ExprNode) -> StmtNode {
+	self.statement(Statement::Out(expr))
     }
 
     pub fn def(&self, name: &str, expr: ExprNode) -> StmtNode {

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,3 +1,5 @@
+// (C) 2021 Brandon Lewis
+
 use crate::ast::{Node, AList, Map};
 use std::cell::RefCell;
 use std::fmt::Debug;

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -1,6 +1,8 @@
+// (C) 2021 Brandon Lewis
+//
 // LALRPOP grammar for the VM front-end.
 //
-// Adapted from that found in the `amath` crate, with heavy additions.
+// Expression grammar is adapted from the the `amath` crate, with heavy additions.
 // https://github.com/vpzomtrrfrt/amath/blob/master/src/grammar.lalrpop
 
 use crate::ast;
@@ -235,7 +237,7 @@ TypeDef: StmtNode
 // Send a value downstream on the output channel.
 Effect: StmtNode
     = "out" <value:Expr> ";"
-    => ast.emit(value);
+    => ast.out(value);
 
 
 // Bind a name to a value.

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -151,11 +151,11 @@ pub Member: (&'input str, ast::Member) = {
 	=> ast.field(name, t),
     "field?" <name:Id> ":" <t:Type>
 	=> ast.opt_field(name, t),
-    "method" <name:Id> <args:Arglist> "->" <ret:Type> "=" <body:Expr>
+    "method" <name:Id> <args:Arglist> "->" <ret:Type> <body:Expr>
 	=> ast.method(name, &args, ret, body),
     "const" <name:Id> ":" <t:Type> "=" <value:Expr>
 	=> ast.static_val(name, t, value),
-    "static" <name:Id> <args:Arglist> "->" <ret:Type> "=" <body:Expr>
+    "static" <name:Id> <args:Arglist> "->" <ret:Type> <body:Expr>
 	=> ast.static_method(name, &args, ret, body),
 }
 
@@ -311,13 +311,21 @@ Arglist: Vec<(&'input str, TypeNode)>
 
 
 // An anonymous function expression.
-Lambda: ExprNode
-    = <args:Arglist> <ret:("->" <Type>)?> "=" <body:Expr>
-    => ast.lambda(
-	&args,
-	ret.unwrap_or(ast.t_void.clone()),
-	body
-    );
+Lambda: ExprNode = {
+    <args:Arglist> <ret:("->" <Type>)?> "=" <body:SimpleExpr>
+	=> ast.lambda(
+	    &args,
+	    ret.unwrap_or(ast.t_void.clone()),
+	    body
+	),
+    <args:Arglist> <ret:("->" <Type>)?> <body:Block>
+	=> ast.lambda(
+	    &args,
+	    ret.unwrap_or(ast.t_void.clone()),
+	    body
+	),
+}
+    
 
 
 // A sequence of statements treated as an expression.

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -80,16 +80,18 @@ pub Statement: StmtNode = {
     TypeDef,
     Effect,
     Let,
-    EffectExpr,
+    CondStmt,
     Iteration,
     EffectCapture,
-    Suppose
+    TemplateCall,
+    NonEmptyBlockStmt => ast.expr_for_effect(<>),
+    Suppose,
 }
 
 
 // Expression entry point.
 pub Expr: ExprNode = {
-    Block,
+    BlockExpr,
     SimpleExpr,
 }
 
@@ -131,8 +133,10 @@ pub TypeTerm: TypeNode = {
     "Str"                       => ast.t_str.clone(),
     "Point"                     => ast.t_point.clone(),
     "Self"                      => ast.t_this.clone(),
+    "Any"                       => ast.t_any.clone(),
     <TypeName>                  => ast.type_name(<>),
     <Record>                    => <>,
+    "{" <Type> "}"              => ast.t_map(<>),
     "(" <Type> ")"              => <>,
     "<" <items:Comma<Type>> ">" => ast.tuple(&items),
     "[" <item:Type> "]"         => ast.t_list(item)
@@ -190,13 +194,13 @@ ImportSelector: ast::ImportSelector = {
 
 // Syntactic sugar for defining a function returning a value.
 FuncDef: StmtNode
-    = "func" <name:Id> <args:Arglist> "->" <ret:Type> <body:Block>
+    = "func" <name:Id> <args:Arglist> "->" <ret:Type> <body:BlockExpr>
     => ast.def(name, ast.lambda(&args, ret, body));
 
 
 // Syntatic sugar for defining a function which returns no value.
 ProcDef: StmtNode
-    = "proc" <name:Id> <args:Arglist> <body:Block>
+    = "proc" <name:Id> <args:Arglist> <body:BlockStmt>
     => ast.def(name, ast.lambda(&args, ast.t_void.clone(), body));
 
 
@@ -218,7 +222,7 @@ OutputDecl: TypeNode
 // consumes a trailing block. This allows defining library functions
 // which feel like control structures.
 TemplateDef: StmtNode
-    = "template" <name:Id> <args:Arglist> "using" <delegate:Id> <body:Block>
+    = "template" <name:Id> <args:Arglist> "using" <delegate:Id> <body:BlockStmt>
     => ast.def(name, ast.template(&args, delegate, body));
 
 
@@ -240,22 +244,57 @@ Let: StmtNode
     => ast.def(name, value);
 
 
-// An expression evaluated for its side effects in a statement context.
-//
-// To keep the LALRPOP happy, this is a subset of expressions.
-EffectExpr: StmtNode = {
-    <Cond> => ast.expr_for_effect(<>),
-    TemplateCall,
-}
+// An if-else chain in a statement context
+CondStmt: StmtNode
+    = "if"
+      <first:CondStmtClause>
+      <rest:("elif" <CondStmtClause>)*>
+      <default:("else" <BlockStmt>)?>
+    => {
+        let mut clauses = vec!{first};
+        clauses.extend(rest);
+        ast.expr_for_effect(
+	    ast.cond(clauses.as_slice(),
+		     default.unwrap_or(ast.void.clone())
+	    )
+	)
+    }
+;
+
+
+// A single clause in an if-else statement.
+CondStmtClause: (ExprNode, ExprNode)
+    = "(" <pred: Expr> ")" <body: BlockStmt>
+    => (pred, body);
 
 
 // Iterate over a collection.
 Iteration: StmtNode = {
-    "for" <name:Id> "in" <list:Expr> <body:Block>
+    "for" <name:Id> "in" <list:Expr> <body:BlockStmt>
 	=> ast.list_iter(name, list, ast.expr_for_effect(body)),
-    "for" "(" <key:Id> "," <value:Id> ")" "in" <map:Expr> <body:Block>
+    "for" "(" <key:Id> "," <value:Id> ")" "in" <map:Expr> <body:BlockStmt>
 	=> ast.map_iter(key, value, map, ast.expr_for_effect(body))
 }
+
+
+// A sequence of statements with nested scope.
+//
+// Unlike BlockExpr, this does *not* allow a trailing expression.  We
+// still return ExprNode here because the distinction is entirely
+// syntactic.
+BlockStmt: ExprNode = {
+    "{" <Statement+> "}" => ast.block(&<>, ast.void.clone()),
+    "{" "}" => ast.void.clone()
+}
+
+
+// A sequence of statements with nested scope.
+//
+// Unlike BlockStmt, this cannot be empty. Needed to avoid ambiguity
+// in top-level statements.
+NonEmptyBlockStmt: ExprNode
+    = "{" <Statement+> "}"
+    => ast.block(&<>, ast.void.clone());
 
 
 // Binds to captured output in suppose()
@@ -276,17 +315,17 @@ MaybeExpr: ExprNode = {
 // Any expression which is not a block. 
 SimpleExpr: ExprNode = {
     Lambda,
-    Cond,
+    CondExpr,
     Logic,
 }
 
 
-// An if-else chain
-Cond: ExprNode
+// An if-else chain in an expression context.
+CondExpr: ExprNode
     = "if"
-      <first:CondClause>
-      <rest:("elif" <CondClause>)*>
-      <default:("else" <Block>)?>
+      <first:CondExprClause>
+      <rest:("elif" <CondExprClause>)*>
+      <default:("else" <BlockExpr>)?>
     => {
         let mut clauses = vec!{first};
         clauses.extend(rest);
@@ -295,15 +334,15 @@ Cond: ExprNode
 ;
 
 
-// Single clause in an if-else chain
-CondClause: (ExprNode, ExprNode)
-    = "(" <pred: Expr> ")" <body: Block>
+// Single clause in an if-else expression.
+CondExprClause: (ExprNode, ExprNode)
+    = "(" <pred: Expr> ")" <body: BlockExpr>
     => (pred, body);
 
 
 // The subjunctive construct, as documented in github issue #20
 Suppose: StmtNode
-    = "suppose" "(" <delegate:Expr> ")" <branch:Block> "else" <leaf:Block>
+    = "suppose" "(" <delegate:Expr> ")" <branch:BlockStmt> "else" <leaf:BlockStmt>
     => ast.suppose(delegate, ast.expr_for_effect(branch), ast.expr_for_effect(leaf));
 
 
@@ -319,26 +358,35 @@ Arglist: Vec<(&'input str, TypeNode)>
     => args;
 
 
-// An anonymous function expression.
+// An anonymous function / procedure expression.
 Lambda: ExprNode = {
     <args:Arglist> <ret:("->" <Type>)?> "=" <body:SimpleExpr>
 	=> ast.lambda(
 	    &args,
-	    ret.unwrap_or(ast.t_void.clone()),
+	    ret.unwrap_or(ast.t_any.clone()),
 	    body
 	),
-    <args:Arglist> <ret:("->" <Type>)?> <body:Block>
+    <args:Arglist> <ret:("->" <Type>)> <body:BlockExpr>
 	=> ast.lambda(
 	    &args,
-	    ret.unwrap_or(ast.t_void.clone()),
+	    ret,
+	    body
+	),
+    <args:Arglist> <body:BlockStmt>
+	=> ast.lambda(
+	    &args,
+	    ast.t_void.clone(),
 	    body
 	),
 }
     
 
 
-// A sequence of statements treated as an expression.
-Block: ExprNode = {
+// A sequence of statements with a trailing expression.
+//
+// This trailing expression is *not* optional in an expression
+// context.
+BlockExpr: ExprNode = {
     "{" <stmts:Statement+> <ret:MaybeExpr> "}"
         => ast.block(&stmts, ret),
     "{" <ret:MaybeExpr> "}"
@@ -346,7 +394,6 @@ Block: ExprNode = {
 }
 
 
-// Expression entry point anow, this is the logic operators. This way
 // sloppily-parenthesized logic hould do the least surprising thing.
 Logic: ExprNode = {
     <a:Logic> "and" <b:Rel> => ast.bin(ast::BinOp::And, a, b),
@@ -356,7 +403,8 @@ Logic: ExprNode = {
 }
 
 
-// Relational operators are the next highest precedence.
+// sloppily-parenthesized relational operators should also do the
+// least surprising thing.
 Rel: ExprNode = {
     <a:Rel> "<"  <b:Sum> => ast.bin(ast::BinOp::Lt, a, b),
     <a:Rel> ">"  <b:Sum> => ast.bin(ast::BinOp::Gt, a, b),
@@ -406,7 +454,7 @@ InvTerm: ExprNode = {
 // To simplify the grammar, templates are assumed not to return a
 // value and are purely used for their effects.
 TemplateCall: StmtNode = {
-    <func:Call> "(" <args:Args> ")" <delegate:Block>
+    <func:Call> "(" <args:Args> ")" <delegate:BlockStmt>
 	=> ast.template_call(func, &args, delegate),
     <func:Call> "(" <args:Args> ")" ";"
         => ast.expr_for_effect(ast.call(func, &args))

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -379,7 +379,6 @@ Lambda: ExprNode = {
 	    body
 	),
 }
-    
 
 
 // A sequence of statements with a trailing expression.

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -90,7 +90,7 @@ pub Statement: StmtNode = {
 // Expression entry point.
 pub Expr: ExprNode = {
     Block,
-    SimpleExpr
+    SimpleExpr,
 }
 
 
@@ -262,9 +262,18 @@ Iteration: StmtNode = {
 EffectCapture: StmtNode = "..." ";" => ast.effect_capture.clone();
 
 
-// Any expression which is not a Block.
+// The trailing expression in a block.
 //
-// Needed to avoid the abiguity of nesting blocks.
+// Needed to avoid the abiguity of nesting blocks, and to restrict the
+// `done` keyword to this position only. You should not be able to
+// name `void` in general.
+MaybeExpr: ExprNode = {
+    "done" => ast.void.clone(),
+    SimpleExpr,
+}
+
+
+// Any expression which is not a block. 
 SimpleExpr: ExprNode = {
     Lambda,
     Cond,
@@ -329,12 +338,10 @@ Lambda: ExprNode = {
 
 
 // A sequence of statements treated as an expression.
-//
-// If the `yield` keyword is present, then this block has a value.
 Block: ExprNode = {
-    "{" <stmts:Statement+> <ret:("yield" <SimpleExpr>)?> "}"
-        => ast.block(&stmts, ret.unwrap_or(ast.void.clone())),
-    "{" <ret:("yield" <SimpleExpr>)> "}"
+    "{" <stmts:Statement+> <ret:MaybeExpr> "}"
+        => ast.block(&stmts, ret),
+    "{" <ret:MaybeExpr> "}"
 	=> ret,
 }
 
@@ -489,8 +496,8 @@ Boolean: bool         = {"true" => true, "false" => false};
 Str: &'input str      = <s:r#""(([^\\"]|\\.)*)""#> => &s[1..(s.len() - 1)];
 
 
-// Skip whitespace and comments.
 match {
+    // Skip whitespace and comments.
     r"\s*" => { },
     r"//[^\n\r]*[\n\r]*" => { },
     r"/\*([^\*]*\*+[^\*/])*([^\*]*\*+|[^\*])*\*/" => { },

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -67,6 +67,7 @@ Decl: StmtNode = {
     Import,
     FuncDef,
     ProcDef,
+    TemplateDef,
     TypeDef,
     Let,
 }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -345,7 +345,7 @@ CondExprClause: (ExprNode, ExprNode)
 // The subjunctive construct, as documented in github issue #20
 Suppose: StmtNode
     = "suppose" "(" <delegate:Expr> ")" <branch:BlockStmt> "else" <leaf:BlockStmt>
-    => ast.suppose(delegate, ast.expr_for_effect(branch), ast.expr_for_effect(leaf));
+    => ast.suppose(delegate, branch, leaf);
 
 
 // Single paramater in a function signature

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -273,9 +273,9 @@ CondStmtClause: (ExprNode, ExprNode)
 // Iterate over a collection.
 Iteration: StmtNode = {
     "for" <name:Id> "in" <list:Expr> <body:BlockStmt>
-	=> ast.list_iter(name, list, ast.expr_for_effect(body)),
+	=> ast.list_iter(name, list, body),
     "for" "(" <key:Id> "," <value:Id> ")" "in" <map:Expr> <body:BlockStmt>
-	=> ast.map_iter(key, value, map, ast.expr_for_effect(body))
+	=> ast.map_iter(key, value, map, body)
 }
 
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,0 +1,518 @@
+use crate::ast::{
+    self,
+    Node,
+    BinOp,
+    UnOp, Seq,
+    AList,
+    StmtNode,
+    ExprNode,
+    TypeNode,
+    Statement,
+    Program,
+    Expr
+};
+
+use std::collections::hash_map::{HashMap, Entry};
+use std::ops::Deref;
+use std::hash::Hash;
+use std::fmt::Debug;
+
+
+type Addr = u16;
+type Boxed<T> = std::rc::Rc<T>;
+type Float = eq_float::F64;
+
+
+/* Errors occuring when lowering to IR ***************************************/
+
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error {
+    NotCallable(String),
+    Duplicate(String),
+    NotFound(String),
+    IllFormed(String),
+    TypeError(String),
+    TooManyArguments,
+    NotImplemented(String),
+    Internal(String),
+}
+
+
+impl Error {
+    pub fn not_callable<T: Debug, U>(expr: T) -> Result<U> {
+	Err(Self::NotCallable(format!("{:?} is not callable.", expr)))
+    }
+
+    pub fn duplicate<T: Debug, U>(entry: T) -> Result<U> {
+	Err(Self::Duplicate(format!("Redefinition of {:?}.", entry)))
+    }
+
+    pub fn not_found<T: Debug, U>(entry: T) -> Result<U> {
+	Err(Self::NotFound(format!("{:?} is undefined", entry)))
+    }
+
+    pub fn ill_formed<T: Debug, U>(entry: T, context: &str) -> Result<U> {
+	Err(Self::IllFormed(format!("{:?} not allowed in {}", entry, context)))
+    }
+
+    pub fn type_error<T: Debug, U>(expected: T, got: T) -> Result<U> {
+	Err(Self::TypeError(format!("Expected {:?}, got {:?}", expected, got)))
+    }
+
+    pub fn not_implemented<T>(feature: &str) -> Result<T> {
+	Err(Self::NotImplemented(format!("{:?} is not implemented", feature)))
+    }
+
+    pub fn internal<T>(mumbo_jumbo: &str) -> Result<T> {
+	Err(Self::Internal(mumbo_jumbo.to_string()))
+    }
+
+    pub fn too_many_arguments<T>() -> Result<T> {
+	Err(Self::TooManyArguments)
+    }
+}
+
+
+
+/* Utility Classes (candidate for moving into lib.rs, or elsewhwere) ***********/
+
+
+// A bi-directional vector which maps *from* and *to* numeric indices.
+//
+// The only insertion operation supported is `push`.
+//
+// Use `try_push` when inserting a duplicate should be considered an
+// error.
+pub struct BiVec<T: Hash> {
+    to_index: HashMap<T, usize>,
+    from_index: Vec<T>
+}
+
+
+impl<T: Hash + Eq + Clone + Debug> BiVec<T> {
+    pub fn new() -> Self {
+	Self {
+	    to_index: HashMap::new(),
+	    from_index: Vec::new()
+	}
+    }
+
+    // Append a new value, if needed, and return its index.
+    pub fn push(&mut self, value: T) -> usize {
+	let count = self.from_index.len();
+	match self.to_index.entry(value.clone()) {
+	    Entry::Vacant(e) => {
+		e.insert(count);
+		self.from_index.push(value);
+		count
+	    },
+	    Entry::Occupied(e) => *e.get()
+	}
+    }
+
+    // Try to append a new value, but error if value is already present.
+    pub fn try_push(&mut self, value: T) -> Result<usize> {
+	let count = self.from_index.len();
+	match self.to_index.entry(value.clone()) {
+	    Entry::Vacant(e) => {
+		e.insert(count);
+		self.from_index.push(value);
+		Ok(count)
+	    },
+	    _ => Error::duplicate(value)
+	}
+    }
+
+    // Get the index of value.
+    pub fn index(&self, value: &T) -> Result<usize> {
+	if let Some(count) = self.to_index.get(value) {
+	    Ok(*count)
+	} else {
+	    Error::not_found(value)
+	}
+    }
+
+    // Return a copy of the inner vector.
+    pub fn to_vec(&self) -> Vec<T> {
+	self.from_index.clone()
+    }
+
+    // Convert ourselves into a vector.
+    pub fn into_vec(self) -> Vec<T> {
+	self.from_index
+    }
+
+    // Expose our size
+    pub fn len(&self) -> usize {
+	return self.from_index.len()
+    }
+}
+
+
+// Handles logic around definitions / declarations.
+pub struct ScopeChain<T> {
+    scopes: Vec<(BiVec<String>, HashMap<String, T>)>
+}
+
+
+impl<T> ScopeChain<T> {
+    fn new() -> ScopeChain<T> {
+	ScopeChain {
+	    scopes: Vec::new()
+	}
+    }
+
+    fn top(&self) -> &(BiVec<String>, HashMap<String, T>) {
+	&self.scopes[self.scopes.len() - 1]
+    }
+
+    fn top_mut(&mut self) -> &mut (BiVec<String>, HashMap<String, T>) {
+	let len = self.scopes.len() - 1;
+	&mut self.scopes[len]
+    }
+
+    fn push(&mut self) -> Result<()> {
+	if self.scopes.len() < 256 {
+	    self.scopes.push((BiVec::new(), HashMap::new()));
+	    Ok(())
+	} else {
+	    Error::too_many_arguments()
+	}
+    }
+
+    fn pop(&mut self) -> Result<(BiVec<String>, HashMap<String, T>)> {
+	if let Some(scope) = self.scopes.pop() {
+	    Ok(scope)
+	} else {
+	    Error::internal("Scope chain underflow.")
+	}
+    }
+
+    fn define(&mut self, id: &str, value: T) -> Result<()> {
+	let (indices, values) = self.top_mut();
+
+	if indices.len() <= 256 {
+	    indices.try_push(id.to_string())?;
+	    values.insert(id.to_string(), value);
+	    Ok(())
+	} else {
+	    Error::too_many_arguments()
+	}
+    }
+
+    fn index(&self, id: &str) -> Result<(u8, u8)> {
+	// XXX: slightly annoying to have to make a copy for a look-up
+	// it's due to BiVec being generic over T, and not specialized
+	// for `String` / borrowing.
+	let id = id.to_string();
+
+	for (scope, (indices, values)) in self.scopes.iter().rev().enumerate() {
+	    if values.contains_key(&id) {
+		return Ok((scope as u8, indices.index(&id.to_string())? as u8))
+	    }
+	}
+
+	Error::not_found(id)
+    }
+}
+
+
+
+/* IR ************************************************************************/
+
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum CallType {
+    Always,
+    If(bool)
+}
+
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum IndexType {
+    List,
+    Map,
+    Record
+}
+
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(u32)]
+pub enum Instruction {
+    Const(Addr),
+    Arg(u8, u8),
+    Def(u8),
+    Un(UnOp),
+    Bin(BinOp),
+    Call(CallType),
+    In,
+    Out,
+    Debug,
+    Drop(u8),
+    Dup(u8),
+    Swap(u8, u8),
+    Placeholder,
+    Index(IndexType),
+    Matches,
+    Coerce,
+}
+
+
+type Block = Vec<Instruction>;
+
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Value {
+    Int(u64),
+    Float(Float),
+    Str(String),
+    Type(Boxed<TypeTag>),
+    Lambda {
+	code: Block,
+	args: u8,
+	rets: u8,
+	captures: Vec<Value>
+    },
+    List(Vec<Value>),
+    Map(Vec<(String, Value)>),
+    Record(Boxed<TypeTag>, Vec<Value>)
+}
+
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+// XXX: placeholder type for now. ast::TypeTag isn't hashable. It may
+// also be too heavyweight. We need a FrozenMap from an external crate
+// for some variants.
+pub enum TypeTag {
+    Int,
+    Float,
+    Str,
+    Type,
+    Lambda(u8, u8),
+    List,
+    Map,
+    Record
+}
+
+    
+// A source file compiles to a executable or a module.
+#[derive(Clone, Debug, PartialEq)]
+pub enum IR {
+    Executable(Executable),
+    Module(Module)
+}
+
+
+// The complete output of compiled program, including all dependencies.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Executable {
+    pub desc: String,
+    pub input: ast::TypeTag,
+    pub output: ast::TypeTag,
+    pub data: Vec<Value>,
+    pub code: Vec<Block>,
+}
+
+
+// A source file becomes
+#[derive(Clone, Debug, PartialEq)]
+pub struct Module {
+    pub desc: String,
+    pub types: HashMap<String, TypeNode>,
+    pub values: HashMap<String, Value>,
+}
+
+
+// Bookeeping enumeration for lexical bindings
+#[derive(Clone, Debug, PartialEq)]
+pub enum Binding {
+    Argument(u8, TypeNode),
+    Local(u8, TypeNode),
+    Capture(u8, TypeNode)
+}
+
+
+// Holds state required to process an AST into IR.
+pub struct Compiler {
+    data: BiVec<Value>,
+    output: Vec<Instruction>,
+    scopes: ScopeChain<Binding>,
+    // TBD: scope chain / stack
+    // TBD: modules.
+}
+
+
+/* IR Impls ******************************************************************/
+
+
+impl Compiler {
+    pub fn new() -> Self {
+	Self {
+	    data: BiVec::new(),
+	    output: Vec::new(),
+	    scopes: ScopeChain::new(),
+	}
+    }
+
+    // Try to convert the AST to IR
+    pub fn compile_program(&mut self, prog: Program) -> Result<IR> {
+	Ok(match prog {
+	    Program::Script {desc, decls, input, output, body}
+	    => IR::Executable(self.compile_script(desc, decls, input, output, body)?),
+	    Program::Library {desc, decls}
+	    => IR::Module(self.compile_library(desc, decls)?)
+	})
+    }
+
+
+    // Try to compile a script to an IR executable.
+    pub fn compile_script(
+	&mut self,
+	desc: String,
+	decls: Seq<Statement>,
+	input: TypeNode,
+	output: TypeNode,
+	body: Seq<Statement>
+    ) -> Result<Executable> {
+	self.scopes.push();
+
+	for d in decls {
+	    self.compile_statement(&d)?;
+	}
+
+	for statement in body {
+	    self.compile_statement(&statement)?;
+	}
+
+	self.scopes.pop()?;
+
+	Ok(Executable {
+	    desc,
+	    input: Node::try_unwrap(input).unwrap(),
+	    output: Node::try_unwrap(output).unwrap(),
+	    data: self.data.to_vec(),
+	    code: vec![self.output.clone()]
+	})
+    }
+
+    // Try to compile a libray to an IR module.
+    pub fn compile_library(
+	&mut self,
+	desc: String,
+	decls: Vec<StmtNode>
+    ) -> Result<Module> {
+	self.scopes.push();
+
+	for d in decls {
+	    self.compile_statement(&d)?;
+	}
+
+	self.scopes.pop()?;
+
+	// TBD: extract top-level scope decls to hashmap.
+
+	Error::not_implemented("Libraries")
+    }
+
+    // Try to compile a statement to instructions.
+    //
+    // The instructions will be placed in the output block.
+    pub fn compile_statement(&mut self, statement: &StmtNode) -> Result<()> {
+	Error::not_implemented("Anything at all")
+    }
+
+    // Try to compile a block to instructions.
+    //
+    // The instructions will be placed in the output block.
+    pub fn compile_block(&mut self, stmts: &[StmtNode], ret: ExprNode) -> Result<()> {
+	self.scopes.push();
+
+	for statement in stmts {
+	    self.compile_statement(statement)?;
+	}
+
+	self.compile_expr(&ret)?;
+	self.scopes.pop()?;
+	
+	Ok(())
+    }
+
+    // Try to compile an expression to instructions.
+    //
+    // The instructions will be placed in the output block.
+    pub fn compile_expr(&mut self, expr: &ExprNode) -> Result<()> {
+	Error::not_implemented("Expressions")
+    }
+
+    // A constant value will be replaced with a Const instruction in
+    // the output.
+    //
+    // We need to look up the value in our table to get its index. If
+    // this value has already been seen, it will be re-used.
+    pub fn compile_const(&mut self, val: Value) -> Result<()> {
+	// XXX: handle address overflow.
+	let addr = self.data.push(val) as u16;
+	self.emit(Instruction::Const(addr));
+	Ok(())
+    }
+
+    // Emit an instruction to the output.
+    pub fn emit(&mut self, inst: Instruction) {
+	self.output.push(inst)
+    }
+}
+
+
+impl Instruction {
+    // The argument arity of an instruction may depend on the top-most
+    // stack value.
+    pub fn arity(self, top: &Value) -> Result<(u8, u8)> {
+	match self {
+	    Instruction::Const(_)      => Ok((0, 1)),
+	    Instruction::Arg(_, _ )    => Ok((0, 1)),
+	    Instruction::Def(_)        => Ok((1, 0)),
+	    Instruction::Un(_)         => Ok((1, 1)),
+	    Instruction::Bin(_)        => Ok((2, 1)),
+	    Instruction::In            => Ok((0, 1)),
+	    Instruction::Out           => Ok((1, 0)),
+	    Instruction::Debug         => Ok((0, 0)),
+	    Instruction::Drop(n)       => Ok((n, 0)),
+	    Instruction::Swap(x, y)    => Ok((0, 0)),
+	    Instruction::Dup(n)        => Ok((0, n)),
+	    Instruction::Placeholder   => Ok((0, 1)),
+	    Instruction::Index(_)      => Ok((2, 1)),
+	    Instruction::Coerce        => Ok((2, 1)),
+	    Instruction::Matches       => Ok((2, 1)),
+	    Instruction::Call(variant) => self.call_arity(variant, top)
+	}
+    }
+
+    pub fn call_arity(self, ct: CallType, top: &Value) -> Result<(u8, u8)> {
+	if let &Value::Lambda {code: _, args, rets, captures: _} = top {
+	    match ct {
+		CallType::Always => Ok((1 + args, rets)),
+		CallType::If(_)  => Ok((2 + args, rets))
+	    }
+	} else {
+	    Error::not_callable(top)
+	}
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::grammar;
+    use crate::ast::*;
+    use super::*;
+
+    #[test]
+    pub fn test_simple() {
+    }
+}

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -807,7 +807,6 @@ impl Compiler {
 	   TypeDef(id, t)      => self.compile_typedef(id, t),
 	   ListIter(i, l, b)   => self.compile_iter(&[i], l, b),
 	   MapIter(k, v, m, b) => self.compile_iter(&[k, v], m, b),
-	   While(_, _)         => Error::not_implemented("while loops"),
 	   Suppose(c, b, l)    => self.compile_subjunctive(c, b, l),
 	   EffectCapture       => self.emit(Instruction::Capture(CaptureOp::Send))
 	}

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -362,6 +362,17 @@ pub struct Lambda {
 }
 
 
+impl Lambda {
+    // Return the arity of the call instruction according to its type.
+    pub fn arity(&self, ct: CallType) -> u8 {
+	match ct {
+	    CallType::Always => 1 + self.args,
+	    CallType::If(_)  => 2 + self.args,
+	    CallType::IfElse => 3 + self.args,
+	}
+    }
+}
+
 // An instance of a record-value.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct RecordValue {
@@ -791,44 +802,6 @@ impl Compiler {
 	let top = self.blocks.len() - 1;
 	self.blocks[top].push(inst);
 	Ok(())
-    }
-}
-
-
-impl Instruction {
-    // The argument arity of an instruction may depend on the top-most
-    // stack value.
-    pub fn arity(self, top: &Value) -> Result<(u8, u8)> {
-	match self {
-	    Instruction::Const(_)      => Ok((0, 1)),
-	    Instruction::Arg(_, _ )    => Ok((0, 1)),
-	    Instruction::Def(_)        => Ok((1, 0)),
-	    Instruction::Un(_)         => Ok((1, 1)),
-	    Instruction::Bin(_)        => Ok((2, 1)),
-	    Instruction::In            => Ok((0, 1)),
-	    Instruction::Out           => Ok((1, 0)),
-	    Instruction::Debug         => Ok((0, 0)),
-	    Instruction::Drop(n)       => Ok((n, 0)),
-	    Instruction::Swap(_, _)    => Ok((0, 0)),
-	    Instruction::Dup(n)        => Ok((0, n)),
-	    Instruction::Placeholder   => Ok((0, 1)),
-	    Instruction::Index(_)      => Ok((2, 1)),
-	    Instruction::Coerce        => Ok((2, 1)),
-	    Instruction::Matches       => Ok((2, 1)),
-	    Instruction::Call(variant) => self.call_arity(variant, top)
-	}
-    }
-
-    pub fn call_arity(self, ct: CallType, top: &Value) -> Result<(u8, u8)> {
-	if let Value::Lambda(l)  = top {
-	    match ct {
-		CallType::Always => Ok((1 + l.args, l.rets)),
-		CallType::If(_)  => Ok((2 + l.args, l.rets)),
-		CallType::IfElse => Ok((3 + l.args, l.rets)),
-	    }
-	} else {
-	    Error::not_callable(top)
-	}
     }
 }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -3,17 +3,14 @@ use crate::ast::{
     Node,
     BinOp,
     UnOp, Seq,
-    AList,
     StmtNode,
     ExprNode,
     TypeNode,
     Statement,
     Program,
-    Expr
 };
 
 use std::collections::hash_map::{HashMap, Entry};
-use std::ops::Deref;
 use std::hash::Hash;
 use std::fmt::Debug;
 
@@ -380,7 +377,7 @@ impl Compiler {
 	output: TypeNode,
 	body: Seq<Statement>
     ) -> Result<Executable> {
-	self.scopes.push();
+	self.scopes.push()?;
 
 	for d in decls {
 	    self.compile_statement(&d)?;
@@ -407,7 +404,7 @@ impl Compiler {
 	desc: String,
 	decls: Vec<StmtNode>
     ) -> Result<Module> {
-	self.scopes.push();
+	self.scopes.push()?;
 
 	for d in decls {
 	    self.compile_statement(&d)?;
@@ -431,7 +428,7 @@ impl Compiler {
     //
     // The instructions will be placed in the output block.
     pub fn compile_block(&mut self, stmts: &[StmtNode], ret: ExprNode) -> Result<()> {
-	self.scopes.push();
+	self.scopes.push()?;
 
 	for statement in stmts {
 	    self.compile_statement(statement)?;
@@ -483,7 +480,7 @@ impl Instruction {
 	    Instruction::Out           => Ok((1, 0)),
 	    Instruction::Debug         => Ok((0, 0)),
 	    Instruction::Drop(n)       => Ok((n, 0)),
-	    Instruction::Swap(x, y)    => Ok((0, 0)),
+	    Instruction::Swap(_, _)    => Ok((0, 0)),
 	    Instruction::Dup(n)        => Ok((0, n)),
 	    Instruction::Placeholder   => Ok((0, 1)),
 	    Instruction::Index(_)      => Ok((2, 1)),
@@ -508,10 +505,6 @@ impl Instruction {
 
 #[cfg(test)]
 mod tests {
-    use crate::grammar;
-    use crate::ast::*;
-    use super::*;
-
     #[test]
     pub fn test_simple() {
     }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -677,20 +677,20 @@ pub trait Operations {
     } }
 
     operator! { binary eq {
-	(None,           None)           => Bool(true),
-	(Atom(a),        Atom(b))        => Bool(a == b),
-	(Type(a),        Type(b))        => Bool(a == b),
+        (None,           None)           => Bool(true),
+        (Atom(a),        Atom(b))        => Bool(a == b),
+        (Type(a),        Type(b))        => Bool(a == b),
         (Bool(a),        Bool(b))        => Bool(a == b),
         (Int(a),         Int(b))         => Bool(a == b),
         (Float(a),       Float(b))       => Bool(a == b),
         (Str(a),         Str(b))         => Bool(a == b),
-	(Point(a),       Point(b))       => Bool(a == b),
-	(Lambda(a),      Lambda(b))      => Bool(a == b),
-	(Tuple(a),       Tuple(b))       => Bool(a == b),
+        (Point(a),       Point(b))       => Bool(a == b),
+        (Lambda(a),      Lambda(b))      => Bool(a == b),
+        (Tuple(a),       Tuple(b))       => Bool(a == b),
         (List(a),        List(b))        => Bool(a == b),
         (Map(a),         Map(b))         => Bool(a == b),
-	(Record(a),      Record(b))      => Bool(a == b),
-	(Module(a),      Module(b))      => Bool(a == b),
+        (Record(a),      Record(b))      => Bool(a == b),
+        (Module(a),      Module(b))      => Bool(a == b),
         _                                => Bool(false)
     } }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -11,6 +11,7 @@ use crate::ast::{
 };
 
 use std::collections::hash_map::{HashMap, Entry};
+use std::ops::Deref;
 use std::hash::Hash;
 use std::fmt::Debug;
 
@@ -417,11 +418,37 @@ impl Compiler {
 	Error::not_implemented("Libraries")
     }
 
-    // Try to compile a statement to instructions.
-    //
-    // The instructions will be placed in the output block.
+    // Dispatch to each instruction variant
     pub fn compile_statement(&mut self, statement: &StmtNode) -> Result<()> {
-	Error::not_implemented("Anything at all")
+	match statement.deref() {
+	    Statement::Import(_)           => Error::not_implemented("module imports")?,
+	    Statement::Export(_)           => Error::not_implemented("module exports")?,
+	    Statement::ExprForEffect(expr) => self.compile_expr(expr)?,
+	    Statement::Emit(expr)          => self.compile_emit(expr)?,
+	    Statement::Def(id, val)        => self.compile_def(id, val)?,
+	    Statement::TypeDef(id, t)      => self.compile_typedef(id, t)?,
+	    Statement::ListIter(_, _, _)   => Error::not_implemented("list iteration")?,
+	    Statement::MapIter(_, _, _, _) => Error::not_implemented("map iteration")?,
+	    Statement::While(_, _)         => Error::not_implemented("while loops")?,
+	    Statement::Suppose(_, _, _)    => Error::not_implemented("subjunctives")?,
+	    Statement::EffectCapture       => Error::not_implemented("effect captures")?
+	};
+
+	Ok(())
+    }
+
+    pub fn compile_emit(&mut self, expr: &ExprNode) -> Result<()> {
+	self.compile_expr(expr)?;
+	self.emit(Instruction::Out);
+	Ok(())
+    }
+
+    pub fn compile_def(&mut self, id: &str, expr: &ExprNode) -> Result<()> {
+	Error::not_implemented("local bindings")
+    }
+
+    pub fn compile_typedef(&mut self, id: &str, expr: &TypeNode) -> Result<()> {
+	Error::not_implemented("local typedefs")
     }
 
     // Try to compile a block to instructions.

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,10 +1,11 @@
 use crate::ast::{
     self,
     BinOp,
+    Expr,
     ExprNode,
+    Float,
     Node,
     Program,
-    Seq,
     Statement,
     StmtNode,
     TypeNode,
@@ -18,9 +19,7 @@ use std::ops::Deref;
 use std::hash::Hash;
 use std::fmt::Debug;
 
-
-type Addr = u16;
-type Float = eq_float::F64;
+use ordered_float::OrderedFloat;
 
 
 /* Errors occuring when lowering to IR ***************************************/
@@ -75,7 +74,6 @@ impl Error {
 	Err(Self::TooManyArguments)
     }
 }
-
 
 
 /* Utility Classes (candidate for moving into lib.rs, or elsewhwere) ***********/
@@ -153,28 +151,74 @@ impl<T: Hash + Eq + Clone + Debug> BiVec<T> {
 }
 
 
-// Handles logic around definitions / declarations.
+/* ScopeChain datastructure **************************************************/
+
+
+// Provides a one-way association between a name and arbitrary value,
+// two-way association between names and numerical indices, and
+// facilities for collecting the results.
+//
+// The AST uses strings as symbolic identifiers for variable
+// references. This IR is stack-based, and uses numerical
+// indexes.
+//
+// This data-structure helps perform this transformation by letting us
+// associate variable names to both an arbtirary value (type
+// information) *and* its numerical index in the output code.
+//
+// It models a "stack of stacks", where the inner stack is referred to
+// as a "scope". The interface presented is itself stack-based.
+
+
+// A location on the stack for captures
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CapturePath {
+    pub frame: u8,
+    pub index: u8,
+}
+
+// XXX:
+//
+// ScopeChain needs to be a stack of Scope, Where Scope is
+//
+// struct Scope {
+//   arguments: BiVec<String>
+//   locals: BiVec<String>
+//   values: HashMap<String, T>
+// }
+//
+// ArgType is just Local or Capture.
+// Arg and Locals share same index space.
+//
+// We need to eliminate the "double scope push" in the compiler, since our
+// scope indices will be off.
+//
+// 
+
 pub struct ScopeChain<T> {
     scopes: Vec<(BiVec<String>, HashMap<String, T>)>
 }
 
-
 impl<T: Clone + Debug> ScopeChain<T> {
+    // Create a new scope chain.
     pub fn new() -> ScopeChain<T> {
 	ScopeChain {
 	    scopes: Vec::new()
 	}
     }
 
+    // Return a reference to the current scope.
     pub fn top(&self) -> &(BiVec<String>, HashMap<String, T>) {
 	&self.scopes[self.scopes.len() - 1]
     }
 
+    // Return a mutable reference to the current scope.
     pub fn top_mut(&mut self) -> &mut (BiVec<String>, HashMap<String, T>) {
 	let len = self.scopes.len() - 1;
 	&mut self.scopes[len]
     }
 
+    // Allocate a new scope.
     pub fn push(&mut self) -> Result<()> {
 	if self.scopes.len() < 256 {
 	    self.scopes.push((BiVec::new(), HashMap::new()));
@@ -184,6 +228,7 @@ impl<T: Clone + Debug> ScopeChain<T> {
 	}
     }
 
+    // Remove and return the current scope.
     pub fn pop(&mut self) -> Result<(BiVec<String>, HashMap<String, T>)> {
 	if let Some(scope) = self.scopes.pop() {
 	    Ok(scope)
@@ -192,7 +237,7 @@ impl<T: Clone + Debug> ScopeChain<T> {
 	}
     }
 
-    // Pop the top of stack into an ordered list of values.
+    // Pop the current scope into an ordered list of values.
     pub fn pop_values(&mut self) -> Result<Vec<T>> {
 	let (names, mut values) = self.pop()?;
 	Ok(
@@ -203,6 +248,13 @@ impl<T: Clone + Debug> ScopeChain<T> {
 		.collect()
 	)
     }
+
+    // Pop the current scope into a hashmap from name => value.
+    pub fn pop_value_map(&mut self) -> Result<Vec<(String, T)>> {
+	let (_, values) = self.pop()?;
+	Ok(values.into_iter().collect())
+    }
+    
 
     // Add an item, if doesn't already exist, and return the index in
     // the current scope.
@@ -238,7 +290,7 @@ impl<T: Clone + Debug> ScopeChain<T> {
 	}
     }
 
-    // Get the path of `id`, whereever it may be in the scope chain.
+    // Get the path of `id`, wherever it happens to be in the scope chain.
     pub fn get_path(&self, id: &str) -> Result<CapturePath> {
 	// XXX: slightly annoying to have to make a copy for a look-up
 	// it's due to BiVec being generic over T, and not specialized
@@ -281,77 +333,225 @@ impl<T: Clone + Debug> ScopeChain<T> {
 }
 
 
+/* IR Instruction Set ********************************************************/
 
-/* IR ************************************************************************/
+
+// Abstract address of a value in memory somewhere. Keeping small
+// because it's used as an instruction immediate.
+pub type Addr = u16;
 
 
+// This represents the entire instruction set.
+//
+// You can think of this IR as a minimal instruction set over rich
+// types.
+//
+// This is flatter than I would like, but the goal is to avoid the
+// enum bloat that can happen with deeply-nested enumerations in
+// Rust.
+//
+// Since we directly execute vectors of these instructions, it is
+// important to keep the size of this value as small as practical. We
+// do this by making sure that any inner enumeration is `[repr(u8)]`
+// here.
+//
+// One way the above manifests is the decision to separate Const from
+// Load.
+//
+// XXX: Somewhere we should be able to static assert that
+// sizeof(Instruction) <= 64-bits.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Instruction {
+    Const(Addr),        // Load a value from the const table.
+    Load(ArgType, u8),  // Load a local variable, argument, or catpure.
+    Store(u8),          // Store a value as a local variable.
+    Un(UnOp),           // Wraps all unary arithmetic and logic operations.
+    Bin(BinOp),         // Wraps all binary arithmetic and logic operations.
+    Call(CallType),     // Unconditional, conditional, and iterative.
+    In,                 // Place input record on stack.
+    Out,                // Send top of stack to output.
+    Debug,              // Inspect top of stack without altering it.
+    Drop(u8),           // Discard values.
+    Dup(u8),            // Copy values.
+    Swap(u8, u8),       // Exchange two stack indices.
+    Placeholder,        // This value is used in a partial application.
+    Index(IndexType),   // Index into a collection.
+    Matches(TypeTag),   // True if top of stack matches given type.
+    Coerce(TypeTag),    // Try to cast from one type to another.
+    TypeCheck(TypeTag), // Error if top of stack doesn't match expected type.
+    Trap(TrapType)      // Signal an error condition from user code.
+}
+
+
+// The only mechanism for control flow is the Call instruction.
+//
+// This enum specifies the variants of the call instruction, including
+// conditional and iterative forms.
+//
+// The number of 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum CallType {
     Always,
-    If(bool),
-    IfElse
+    If,
+    IfElse,
+    // XXX: TBD
+    // Iterative forms.
 }
 
 
+// There is a single index instruction, which is statically typed.
+//
+// The collection and key type provided to an Index instruction must
+// agree with the variant here.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum IndexType {
     List,
     Map,
-    Record
+    Record,
+    Module
 }
 
 
-// Bookeeping enumeration for lexical bindings
+// There is a single Load instruction for loading data onto the stack.
+// This enum specifies the different address spaces from which we can load
+// values.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Binding {
+#[repr(u8)]
+pub enum ArgType {
     Local,
     Arg,
     Capture
 }
 
 
+// We can trap in two ways: recoverable, and fatal.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[repr(u32)]
-pub enum Instruction {
-    Const(Addr),
-    Arg(Binding, u8),
-    Def(u8),
-    Un(UnOp),
-    Bin(BinOp),
-    Call(CallType),
-    In,
-    Out,
-    Debug,
-    Drop(u8),
-    Dup(u8),
-    Swap(u8, u8),
-    Placeholder,
-    Index(IndexType),
-    Matches,
-    Coerce,
+#[repr(u8)]
+pub enum TrapType {
+    Exception,
+    Fatal
 }
 
 
-// An instruction sequence we can append to
+// A linear sequence of instructions.
+//
+// The block is the basic unit of control flow.
 pub type Block = Vec<Instruction>;
 
 
-// A location on the stack for captures
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct CapturePath {
-    // We use a flat list of captures.
-    pub frame: u8,
-    pub index: u8
+/* IR Values *****************************************************************/
+
+
+// Abstract over memory management.
+pub type Shared<T> = std::rc::Rc<T>;
+pub type Seq<T> = Vec<T>;
+pub type AList<T> = Vec<(String, T)>;
+// XXX: use a real, hashable map type here at some point.
+pub type Map<T> = AList<T>;
+    
+
+// Holds any representable value.
+//
+// It should be cheap to clone this type.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Value {
+    // These values are unboxed.
+    None,
+    Type(TypeTag),
+    Bool(bool),
+    Int(i64),
+    Float(Float),
+    // XXX: box strings, but not right this second.
+    Str(String),
+    // Values below are heavy-weight enough to be boxed.
+    Point(Shared<Point>),
+    Lambda(Shared<Lambda>),
+    Closure(Shared<Lambda>, Shared<Seq<Value>>),
+    Tuple(Shared<Seq<Value>>),
+    List(Shared<Seq<Value>>),
+    Map(Shared<Map<Value>>),
+    Record(Shared<Record>),
+    Module(Shared<DummyModule>),
 }
 
 
+// Placeholder to get this to compile until I can make module
+// hashable
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct DummyModule;
+
+
+// Represents the discriminant of a Value.
+//
+// This is the light-weight type representation used as an immediate
+// in the Instruction enum, so it must be repr(u8).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum TypeTag {
+    None,
+    Type,
+    Bool,
+    Int,
+    Float,
+    Str,
+    Point,
+    Lambda,
+    Closure,
+    Tuple,
+    List,
+    Map,
+    RecordDef,
+    RecordValue,
+    Module,
+}
+
+
+// A record value.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Record {
+    vtable: Shared<Map<Member>>,
+    values: Value
+}
+
+
+// An individual field in a record vtable.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Member {
+    Field(Shared<TypeTag>),
+    Method(Shared<Lambda>),
+    StaticValue(Value),
+    StaticMethod(Shared<Lambda>)
+}
+
+
+// A 2d vector / point value.
+//
 // XXX: implement me optimized
+//
+// I anticipate that this type will be come central to udashboard, if
+// not udlang in general. But we could take it further with 3d, or n-d
+// vectors.
+//
+// Also, it should go without saying that a point is not a vector, and
+// the operations on them are distinct. If we want to be truly
+// type-safe, we'd need both types.
+//
+// For now this is just a pair of floats, and we just leave it here as
+// a placeholder value.
 pub type Point = (Float, Float);
 
 
-// A block of code and the meta-data required to call it.
+// A function value.
+//
+// Since, the only form of control flow is the `Call` instruction, in
+// all its variations, function values are central to this IR.
+//
+// Simply put, a Lambda value is a block, plus the meta-data required
+// to call it. This includes the airty of the function and return
+// values, and the *capture* list, which may be empty, in case the
+// function happens to be a closure.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Lambda {
     pub code: Block,
@@ -367,69 +567,23 @@ impl Lambda {
     pub fn arity(&self, ct: CallType) -> u8 {
 	match ct {
 	    CallType::Always => 1 + self.args,
-	    CallType::If(_)  => 2 + self.args,
+	    CallType::If     => 2 + self.args,
 	    CallType::IfElse => 3 + self.args,
 	}
     }
-}
 
-// An instance of a record-value.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct RecordValue {
-    // XXX: Store TypeTag here, or an equivalent representation. The
-    // idea is that the dot and index operations should be able to
-    // resolve to something at runtime.
+    // Perhaps surprisingly, some operations are supported on
+    // functions.
     //
-    // We should be able to contruct a flattened definition on the
-    // stack when processing record definitions.
+    // In particular functions can be concatenated with each other,
+    // and with instructions. This is used to implement partial
+    // evaluation.
     //
-    // A member may be defined on the class type itself, in which case
-    // indexing that field should a value from the record definition,
-    // otherwise it pulls the value out of the `values` vector.
-    //
-    // Methods will need a way to implicitly bind the value of `self`.
-    // 
-    // pub definition: Map<String, Member>,
-    pub values: Vec<Value>
+    // XXX: TBD thunk folding, see issue #37
 }
 
 
-// Holds any representable value.
-//
-// Since this is IR, we don't bother with boxing values. The goal here
-// is clarity.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Value {
-    Bool(bool),
-    Int(i64),
-    Float(Float),
-    Str(String),
-    Type(TypeTag),
-    Point(Point),
-    Lambda(Lambda),
-    List(Vec<Value>),
-    Map(Vec<(String, Value)>),
-    Record(RecordValue)
-}
-
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-// XXX: placeholder type for now. ast::TypeTag isn't hashable. It may
-// also be too heavyweight. We need a FrozenMap from an external crate
-// for some variants.
-pub enum TypeTag {
-    Int,
-    Float,
-    Str,
-    Type,
-    Lambda(u8, u8),
-    List,
-    Map,
-    Record,
-}
-
-    
-// A source file compiles to a executable or a module.
+// Represents the output of compilation, either a script or a module.
 #[derive(Clone, Debug, PartialEq)]
 pub enum IR {
     Executable(Executable),
@@ -437,39 +591,333 @@ pub enum IR {
 }
 
 
-// The complete output of compiled program, including all dependencies.
+// A udling script source file compiles to an exectuable.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Executable {
     pub desc: String,
     pub input: TypeNode,
     pub output: TypeNode,
-    pub data: Vec<Value>,
+    // All constants live in this table, including function values.
+    // References point either back into this table, or into runtime
+    // storage.
+    pub data: Seq<Value>,
+    // Code blocks with special meaning. For now this is limited to
+    // the library / script entry points.
     pub code: Vec<Block>,
 }
 
 
-// A source file becomes
+// A udlang library source file becomes a module object after lowering
+// to IR.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Module {
     pub desc: String,
-    pub types: HashMap<String, TypeNode>,
-    pub values: HashMap<String, Value>,
+    // XXX: consider implementing hash to just call hash on `path`.
+    // This would possibly make it easier to cache module imports.
+    // pub path: String,
+    pub exports: AList<Value>,
 }
 
 
-// Holds state required to process an AST into IR.
+/* Arithmetic and Logic ******************************************************/
+
+
+// This macro factors out operator implementation boilerplate.
+//
+// There are two variants: binary and unary.
+//
+// They both the take:
+// - the name of the method to define,
+// - a list of <pattern> => <expr>,
+//
+// Basically the patterns express the variants for which a given
+// operator actually yields a value. If no patern matches, the
+// result is a type error.
+macro_rules! operator {
+
+    // Template for a unary operator
+    (unary $name:ident { $( $p:pat => $e:expr ),+ } ) => {
+        #[allow(unreachable_patterns)]
+	fn $name (value: &Value) -> Self::Result {
+            // Bringing Value into scope saves us some characters in
+            // the invocation.
+            use Value::*;
+            match value {
+                $($p => Self::ok($e)),+ ,
+                value => Self::invalid_operand(value)
+            }
+        }
+    };
+
+    // Template for a binary operator
+    (binary $name:ident { $( $p:pat => $e:expr ),+ } ) => {
+	#[allow(unreachable_patterns)]
+        fn $name (a: &Value, b: &Value) -> Self::Result {
+            // Bringing Value into scope saves us some characters the
+            // invocation.
+            use Value::*;
+            match (a, b) {
+                $($p => Self::ok($e)),+ ,
+                (a, b) => Self::invalid_operands(a, b)
+            }
+        }
+    };
+}
+
+
+// Defines behavior of arithmetic and logic operations on values.
+//
+// Factors out a bunch of tedious and repetitive logic we'd otherwise
+// need to implement in slightly different ways.
+//
+// There could be a parent trait which defines everything down to
+// `binary`, leaving out the particular operator implementations.
+// That would allow even greater flexibility.
+pub trait Operations {
+    // An opaque result type, probably a specialization of std::Result.
+    type Result;
+
+    // Default implementations call these methods to handle the result
+    // of operations.
+    fn invalid_operand(t: &Value) -> Self::Result;
+    fn invalid_operands(left: &Value, right: &Value) -> Self::Result;
+    fn invalid_cast(value: &Value, tt: TypeTag) -> Self::Result;
+    fn index_error(collection: &Value, index: &Value) -> Self::Result;
+    fn type_mismatch(value: &Value, tt: TypeTag) -> Self::Result;
+    fn ok(value: Value) -> Self::Result;
+
+    // Operations on compound types may need to construct new shared
+    // values.
+    fn new<T: Clone + Debug>(value: T) -> Shared<T>;
+
+    // Get the type of a value.
+    fn get_type(value: &Value) -> TypeTag {
+	use Value as V;
+	use TypeTag as TT;
+        match value {
+	    V::None          => TT::None,
+	    V::Type(_)	     => TT::Type,
+	    V::Bool(_)	     => TT::Bool,
+	    V::Int(_)	     => TT::Int,
+	    V::Float(_)	     => TT::Float,
+	    V::Str(_)	     => TT::Str,
+	    V::Point(_)	     => TT::Point,
+	    V::Lambda(_)     => TT::Lambda,
+	    V::Closure(_, _) => TT::Closure,
+	    V::Tuple(_)	     => TT::Tuple,
+	    V::List(_)	     => TT::List,
+	    V::Map(_)	     => TT::Map,
+	    V::Record(_)     => TT::RecordValue,
+	    V::Module(_)     => TT::Module
+	}
+    }
+
+    // Describes conversions between variants of Value.
+    fn coerce(value: &Value, tt: TypeTag) -> Self::Result {
+	use Value as V;
+	use TypeTag as TT;
+        match (value, tt) {
+            (V::Bool(_),  TT::Bool)  => Self::ok(value.clone()),
+            (V::Bool(v),  TT::Int)   => Self::ok(V::Int(if *v {0} else {1})),
+            (V::Int(v),   TT::Bool)  => Self::ok(V::Bool(*v != 0)),
+            (V::Int(_),   TT::Int)   => Self::ok(value.clone()),
+            (V::Int(v),   TT::Float) => Self::ok(V::Float(OrderedFloat(*v as f64))),
+            (V::Float(v), TT::Int)   => Self::ok(V::Int(**v as i64)),
+            (V::Float(_), TT::Float) => Self::ok(value.clone()),
+            (V::Str(v),   TT::Bool)  => Self::ok(V::Bool(!v.is_empty())),
+            (V::List(v),  TT::Bool)  => Self::ok(V::Bool(!v.is_empty())),
+            (V::Map(v),   TT::Bool)  => Self::ok(V::Bool(!v.is_empty())),
+	    // XXX: * => string coercion
+	    // XXX: record <=> map coercion.
+	    // XXX: list <=> tuple coercion.
+            (a,           b)         => Self::invalid_cast(a, b)
+        }
+    }
+
+    // True if a value matches the given type tag.
+    fn matches(value: &Value, tt: TypeTag) -> bool {
+	Self::get_type(value) == tt
+    }
+
+    // Dispatch from opcode over all unary operations.
+    fn unary(opcode: UnOp, value: &Value) -> Self::Result {
+	match opcode {
+            UnOp::Not  => Self::not(value),
+            UnOp::Neg  => Self::neg(value),
+            UnOp::Abs  => Self::abs(value)
+	}
+    }
+
+    // Try to index into the given object.
+    fn index(collection: &Value, index: &Value) -> Self::Result {
+	// use Value::*;
+	// TBD: implement me
+	Self::index_error(collection, index)
+    }
+
+    // Dispatch from opcode over all binary operations.
+    fn binary(opcode: BinOp, a: &Value, b: &Value) -> Self::Result {
+	match opcode {
+            BinOp::Add  => Self::add(a, b),
+            BinOp::Sub  => Self::sub(a, b),
+            BinOp::Mul  => Self::mul(a, b),
+            BinOp::Div  => Self::div(a, b),
+	    BinOp::Mod  => Self::modulo(a, b),
+            BinOp::Pow  => Self::pow(a, b),
+            BinOp::And  => Self::bitand(a, b),
+            BinOp::Or   => Self::bitor(a, b),
+            BinOp::Xor  => Self::bitxor(a, b),
+            BinOp::Lt   => Self::lt(a, b),
+            BinOp::Gt   => Self::gt(a, b),
+            BinOp::Lte  => Self::lte(a, b),
+            BinOp::Gte  => Self::gte(a, b),
+            BinOp::Eq   => Self::eq(a, b),
+            BinOp::Shl  => Self::shl(a, b),
+            BinOp::Shr  => Self::shr(a, b),
+            BinOp::Min  => Self::min(a, b),
+            BinOp::Max  => Self::max(a, b)
+	}
+    }
+
+    operator! { unary abs {
+        Int(value)   => Int(value.abs()),
+        Float(value) => Float(ordered_float::OrderedFloat(value.abs()))
+    } }
+
+    operator! { unary not {
+	Bool(value) => Bool(!value),
+	Int(value) => Int(!value)
+    } }
+
+    operator! { unary neg {
+        Int(value)   => Int(-value),
+        Float(value) => Float(-*value)
+    } }
+
+    operator! { binary pow {
+	// XXX* silent coercion of b to u32, since pow is not implemented
+        (Int(a),   Int(b))   => Int(a.pow(*b as u32)),
+        (Float(a), Float(b)) => Float(a.powf(**b).into())
+    } }
+
+    operator! { binary min {
+        (Int(a),   Int(b))   => Int(*a.min(b)),
+        (Float(a), Float(b)) => Float(*a.min(b))
+    } }
+
+    operator! { binary max {
+        (Int(a),   Int(b))   => Int(*a.max(b)),
+        (Float(a), Float(b)) => Float(*a.max(b))
+    } }
+
+    operator! { binary add {
+        (Int(a),   Int(b))   => Int(*a + *b),
+        (Float(a), Float(b)) => Float(*a + *b)
+    } }
+
+    operator! { binary sub {
+        (Int(a),   Int(b))   => Int(*a - *b),
+        (Float(a), Float(b)) => Float(*a - *b)
+    } }
+
+    operator! { binary mul {
+        (Int(a),   Int(b))   => Int(a * b),
+        (Float(a), Float(b)) => Float((*a) * (*b))
+    } }
+
+    operator! { binary div {
+        (Int(a),   Int(b))   => Int(a / b),
+        (Float(a), Float(b)) => Float(*a / *b)
+    } }
+
+    operator! { binary modulo {
+        (Int(a),   Int(b))   => Int(a % b),
+        (Float(a), Float(b)) => Float(*a % *b)
+    } }
+
+    operator! { binary bitand {
+        (Bool(a), Bool(b)) => Bool(a & b),
+        (Int(a),  Int(b))  => Int(a & b)
+    } }
+
+    operator! { binary bitor {
+        (Bool(a), Bool(b)) => Bool(a | b),
+        (Int(a),  Int(b))  => Int(a | b)
+    } }
+
+    operator! { binary bitxor {
+        (Bool(a), Bool(b)) => Bool(a ^ b),
+        (Int(a),  Int(b))  => Int(a ^ b)
+    } }
+
+    operator! { binary shl {
+	(Int(a), Int(b)) => Int(a << b)
+    } }
+
+    operator! { binary shr {
+	(Int(a), Int(b)) => Int(a >> b)
+    } }
+
+    operator! { binary lt {
+        (Int(a),   Int(b))   => Bool(a < b),
+        (Float(a), Float(b)) => Bool(a < b),
+        (Str(a),   Str(b))   => Bool(a < b)
+    } }
+
+    operator! { binary gt {
+        (Int(a),   Int(b))   => Bool(a > b),
+        (Float(a), Float(b)) => Bool(a > b),
+        (Str(a),   Str(b))   => Bool(a > b)
+    } }
+
+    operator! { binary lte {
+        (Int(a),   Int(b))   => Bool(a <= b),
+        (Float(a), Float(b)) => Bool(a <= b),
+        (Str(a),   Str(b))   => Bool(a <= b)
+    } }
+
+    operator! { binary gte {
+        (Int(a),   Int(b))   => Bool(a >= b),
+        (Float(a), Float(b)) => Bool(a >= b),
+        (Str(a),   Str(b))   => Bool(a >= b)
+    } }
+
+    operator! { binary eq {
+	(None,           None)           => Bool(true),
+	(Type(a),        Type(b))        => Bool(a == b),
+        (Bool(a),        Bool(b))        => Bool(a == b),
+        (Int(a),         Int(b))         => Bool(a == b),
+        (Float(a),       Float(b))       => Bool(a == b),
+        (Str(a),         Str(b))         => Bool(a == b),
+	(Point(a),       Point(b))       => Bool(a == b),
+	(Lambda(a),      Lambda(b))      => Bool(a == b),
+	(Tuple(a),       Tuple(b))       => Bool(a == b),
+        (List(a),        List(b))        => Bool(a == b),
+        (Map(a),         Map(b))         => Bool(a == b),
+	(Record(a),      Record(b))      => Bool(a == b),
+	(Module(a),      Module(b))      => Bool(a == b),
+        _                                => Bool(false)
+    } }
+}
+
+
+/* Compiler ******************************************************************/
+
+
+// Compiles an AST to IR.
+//
+// This uses the recursive visitor pattern to construct output
+// incrementally.
 pub struct Compiler {
     data: BiVec<Value>,
     blocks: Vec<Block>,
-    scopes: ScopeChain<TypeNode>,
+    scopes: ScopeChain<ArgType>,
     captures: ScopeChain<CapturePath>,
 }
 
 
-/* IR Impls ******************************************************************/
-
-
 impl Compiler {
+    // Create a new Compiler.
     pub fn new() -> Self {
 	Self {
 	    data: BiVec::new(),
@@ -479,7 +927,7 @@ impl Compiler {
 	}
     }
 
-    // Try to convert the AST to IR
+    // Try to convert the AST to IR.
     pub fn compile_program(&mut self, prog: Program) -> Result<IR> {
 	Ok(match prog {
 	    Program::Script {desc, decls, input, output, body}
@@ -489,15 +937,14 @@ impl Compiler {
 	})
     }
 
-
     // Try to compile a script to an IR executable.
     pub fn compile_script(
 	&mut self,
 	desc: String,
-	decls: Seq<Statement>,
+	decls: Seq<Shared<Statement>>,
 	input: TypeNode,
 	output: TypeNode,
-	body: Seq<Statement>
+	body: Seq<Shared<Statement>>
     ) -> Result<Executable> {
 	self.scopes.push()?;
 
@@ -525,71 +972,71 @@ impl Compiler {
     // Try to compile a libray to an IR module.
     pub fn compile_library(
 	&mut self,
-	_desc: String,
+	desc: String,
 	decls: Vec<StmtNode>
     ) -> Result<Module> {
 	self.scopes.push()?;
-
 	for d in decls {
 	    self.compile_statement(&d)?;
 	}
-
-	self.scopes.pop()?;
-
-	// TBD: extract top-level scope decls to hashmap.
-
-	Error::not_implemented("Libraries")
+	let _ = self.scopes.pop_value_map()?;
+	Ok(Module {desc, exports: Vec::new()})
     }
 
-    // Dispatch to each instruction variant
+    // Try to compile a statement into IR.
     pub fn compile_statement(&mut self, statement: &StmtNode) -> Result<()> {
 	use ast::Statement::*;
-
-	// Do NOT include a wildcard match in this block, it breaks
-	// exhaustivity analysis.
 	match statement.deref() {
-	   Import(_)           => Error::not_implemented("module imports")?,
-	   Export(_)           => Error::not_implemented("module exports")?,
-	   ExprForEffect(expr) => self.compile_expr(expr)?,
-	   Emit(expr)          => self.compile_emit(expr)?,
-	   Def(id, val)        => self.compile_def(id, val)?,
-	   TypeDef(id, t)      => self.compile_typedef(id, t)?,
-	   ListIter(_, _, _)   => Error::not_implemented("list iteration")?,
-	   MapIter(_, _, _, _) => Error::not_implemented("map iteration")?,
-	   While(_, _)         => Error::not_implemented("while loops")?,
-	   Suppose(_, _, _)    => Error::not_implemented("subjunctives")?,
-	   EffectCapture       => Error::not_implemented("effect captures")?
-	};
-
-	Ok(())
+	   Import(_)           => Error::not_implemented("module imports"),
+	   Export(_)           => Error::not_implemented("module exports"),
+	   ExprForEffect(expr) => self.compile_expr_for_effect(expr),
+	   Out(expr)           => self.compile_out(expr),
+	   Def(id, val)        => self.compile_def(id, val),
+	   TypeDef(id, t)      => self.compile_typedef(id, t),
+	   ListIter(_, _, _)   => Error::not_implemented("list iteration"),
+	   MapIter(_, _, _, _) => Error::not_implemented("map iteration"),
+	   While(_, _)         => Error::not_implemented("while loops"),
+	   Suppose(_, _, _)    => Error::not_implemented("subjunctives"),
+	   EffectCapture       => Error::not_implemented("effect captures")
+	}
     }
 
-    // Compile an ouptut instruction.
-    pub fn compile_emit(&mut self, expr: &ExprNode) -> Result<()> {
+    // Compile a statement which just invokes an expression for its effects.
+    pub fn compile_expr_for_effect(&mut self, expr: &ExprNode) -> Result<()> {
+	self.compile_expr(expr)
+    }
+
+    // Try to compile an ouptut instruction.
+    pub fn compile_out(&mut self, expr: &ExprNode) -> Result<()> {
 	self.compile_expr(expr)?;
 	self.emit(Instruction::Out)
     }
 
-    // Compile a lexical binding
+    // Try to compile a lexical binding
     //
-    // AKA "variable" binding, AKA "let binding" (all values in uDLang
-    // are technically const).
+    // AKA "let", "func", "proc". There are several syntactic forms
+    // which result in a Def() node being inserted.
     pub fn compile_def(&mut self, id: &str, expr: &ExprNode) -> Result<()> {
-	// We need to convert the local name to an argument index.  Do
-	// this first so that recursive function calls will resolve to
-	// the correct stack slot.
+	// We need to convert the local name to an argument index.
+	//
+	// Do this first so that recursive function calls can at least
+	// find their own name on the stack.
 	//
 	// Duplicate definitions are an error, so we use try_insert
 	// rather than insert.
-	let index = self.scopes.try_insert(id, /* XXX */ Node::new(ast::TypeTag::Any))?;
+	let index = self.scopes.try_insert(id, ArgType::Local)?;
+
 	// We need to place the expression representing the value of
 	// the binding onto the stack.
-	self.compile_expr(expr)
-	// Now we can emit the instruction which will consume the
-	// value and store it in the local stack frame.
-	// self.emit(Instruction::Def(index))
+	self.compile_expr(expr)?;
+
+	// This instruction shuffles the top of stack into the correct
+	// place in the stack frame. This is needed because a let
+	// binding can occur anywhere in the body.
+	self.emit(Instruction::Store(index))
     }
 
+    // Similar to above, but we expect a type node instead.
     pub fn compile_typedef(&mut self, _id: &str, _expr: &TypeNode) -> Result<()> {
 	Error::not_implemented("local typedefs")
     }
@@ -606,18 +1053,18 @@ impl Compiler {
 	    Int(i)                  => self.compile_const(Value::Int(*i)),
 	    Float(f)                => self.compile_const(Value::Float(*f)),
 	    Str(s)                  => self.compile_const(Value::Str(s.clone())),
-	    Point(x, y)             => self.compile_const(Value::Point((*x, *y))),
+	    Point(x, y)             => self.compile_const(Value::Point(Shared::new((*x, *y)))),
 	    This                    => Error::not_implemented("self"),
 	    In                      => self.emit(Instruction::In),
 	    Partial                 => self.emit(Instruction::Placeholder),
 	    List(_)                 => Error::not_implemented("list literal"),
 	    Map(_)                  => Error::not_implemented("map literal"),
-	    Id(id)                  => self.compile_lookup(id),
+	    Id(id)                  => self.compile_variable_reference(id),
 	    Dot(_, _)               => Error::not_implemented("fixed index"),
 	    Has(_, _)               => Error::not_implemented("member test"),
 	    Index(_, _)             => Error::not_implemented("computed index"),
 	    Cond(conds, default)    => self.compile_conds(conds, default),
-	    Block(stmts, ret)       => self.compile_block(stmts, ret),
+	    Block(_, _)             => self.compile_block_expr(expr),
 	    BinOp(op, l, r)         => self.compile_bin(*op, l, r),
 	    UnOp(op, operand)       => self.compile_un(*op, operand),
 	    Call(func, args)        => self.compile_call(func, args),
@@ -627,34 +1074,35 @@ impl Compiler {
 	Ok(())
     }
 
-    // A constant value will be replaced with a Const instruction in
-    // the output.
+    // Try to compile a literal / constant value.
     //
-    // We need to look up the value in our table to get its index. If
-    // this value has already been seen, it will be re-used.
+    // The value will be added to the data section if not already
+    // present, and a `Const` instruction placed in the output.
     pub fn compile_const(&mut self, val: Value) -> Result<()> {
 	// XXX: handle address overflow.
-	let addr = self.data.push(val) as u16;
+	let addr = self.data.push(val) as Addr;
 	self.emit(Instruction::Const(addr))
     }
 
-    // Conds
+    // Try to compile an if-else chain.
     //
-    // 
+    // The conditions are compiled directly to the output stream, the
+    // control flow blocks become lambda values invoked by conditional
+    // calls.
     pub fn compile_conds(
 	&mut self,
 	conds: &[(ExprNode, ExprNode)],
 	default: &ExprNode
     ) -> Result<()> {
-	// Compile the if, elif blocks as (cond) (block) (call(true))
+	// Compile the if, elif blocks as (cond) (block) Call(If)
 	let last = conds.len() - 1;
 	for (cond, action) in conds[..last].iter() {
 	    self.compile_expr(cond)?;
 	    self.compile_basic_block(action)?;
-	    self.emit(Instruction::Call(CallType::If(true)))?;
+	    self.emit(Instruction::Call(CallType::If))?;
 	}
 
-	// Compile the Last item as if-else with default.
+	// Compile the Last item as (Cond) (block) (block) Call(IfElse)
 	let (cond, action) = &conds[last];
 	self.compile_expr(cond)?;
 	self.compile_basic_block(action)?;
@@ -662,25 +1110,7 @@ impl Compiler {
 	self.emit(Instruction::Call(CallType::IfElse))
     }
 
-    // Iterate over the statements in a block, and compile each.
-    pub fn compile_block(
-	&mut self,
-	stmts: &[StmtNode],
-	ret: &ExprNode
-    ) -> Result<()> {
-	self.scopes.push()?;
-
-	for statement in stmts {
-	    self.compile_statement(statement)?;
-	}
-
-	self.compile_expr(&ret)?;
-	self.scopes.pop()?;
-	
-	Ok(())
-    }
-
-    // Try to compile a binary operator
+    // Try to compile a binary operator.
     pub fn compile_bin(
 	&mut self,
 	op: BinOp,
@@ -692,7 +1122,7 @@ impl Compiler {
 	self.emit(Instruction::Bin(op))
     }
 
-    // Try to compile a unary operator
+    // Try to compile a unary operator.
     pub fn compile_un(&mut self, op: UnOp, operand: &ExprNode) -> Result<()> {
 	self.compile_expr(operand)?;
 	self.emit(Instruction::Un(op))
@@ -703,8 +1133,6 @@ impl Compiler {
     // Args are placed on the stack in order.
     //
     // foo(1, 2, 3) => [1 2 3 <foo> call]
-    //
-    // Inside the call of foo, arg(0) is 1.
     pub fn compile_call(
 	&mut self,
 	func: &ExprNode,
@@ -717,8 +1145,28 @@ impl Compiler {
 	self.emit(Instruction::Call(CallType::Always))
     }
 
-    // Special case of lambda: a block which takes 0 arguments.
+    // Compile a nested expression block.
+    //
+    // This gets wrapped into a lambda which is immediately called, in
+    // order for lexical scoping to work correctly.
+    //
+    // If you know javascript, this is equivalent to an IIFE.
+    pub fn compile_block_expr(
+	&mut self,
+	expr: &ExprNode
+    ) -> Result<()> {
+	self.compile_basic_block(expr)?;
+	self.emit(Instruction::Call(CallType::Always))
+    }
+
+    // Compile an arbitrary expression to a lambda taking no arguments.
+    //
+    // These are used as the targets of control flow instructions.
     pub fn compile_basic_block(&mut self, body: &ExprNode) -> Result<()> {
+	match body.deref() {
+	    Expr::Block(_, _) => Ok(()),
+	    _ => Error::internal("not a block!")
+	}?;
 	self.compile_lambda(&[], /* XXX */ &Node::new(ast::TypeTag::Any), body)
     }
 
@@ -729,31 +1177,46 @@ impl Compiler {
 	ret: &TypeNode,
 	body: &ExprNode
     ) -> Result<()> {
-	// First we put the formal parameters into scope.
+	// First we put the formal parameters, if any, into scope.
 	self.scopes.push()?;
 	for (id, _) in args {
-	    // Duplicate parameter names would be an error, so let's
-	    // flag that here by using try_insert.
-	    self.scopes.try_insert(id, /* XXX */ Node::new(ast::TypeTag::Any))?;
+	    // Duplicate parameter names would be an error, hence
+	    // try_insert.
+	    self.scopes.try_insert(id, ArgType::Arg)?;
 	}
 
-	// Now we push an inner scope for local bindings.
-	self.scopes.push()?;
 	// Push the capture scope.
 	self.captures.push()?;
 
 	// Create a code block to hold the lambda's code.
 	self.blocks.push(Block::new());
+
 	// Compile the body.
-	self.compile_expr(body)?;
+	//
+	// The special case here is if expr is a block, then we don't
+	// want this to recurse into compile_block_expr, which would
+	// ultimately call compile_lambda in an infinite loop.
+	//
+	// We just want to compile the statements and return
+	// expression directly into the lambda block.
+	match body.deref() {
+	    Expr::Block(stmts, ret) => {
+		for statement in stmts {
+		    self.compile_statement(statement)?;
+		}
+		self.compile_expr(&ret)?;
+	    },
+	    // But for any other expression variant, we *do* just
+	    // recurse into compile_expr.
+	    _ => self.compile_expr(body)?,
+	};
 
 	// Pop our code and capture list off their respective stacks.
 	let code = self.blocks.pop().expect("Block stack underflow");
 	let captures = self.captures.pop_values()?;
-
-	// Compute the rest of the meta-data we need
 	let locals = self.scopes.pop()?.0.len() as u8;
-	let args = self.scopes.pop()?.0.len() as u8;
+	let args = args.len() as u8;
+
 	let rets = match ret.deref() {
 	    ast::TypeTag::Void => 0,
 	    // XXX: may need to multiple return values at some point,
@@ -762,21 +1225,24 @@ impl Compiler {
 	    _ => 1
 	};
 
-	// Now this is key: the actual value is placed on the stack as
-	// a *constant value*.
-	self.compile_const(Value::Lambda(Lambda {
+	// Now this is key: the lambda is a *literal value*, so it
+	// actually becomes a `Const(x)` in the output instruction
+	// stream.
+	//
+	// The actual lambda value we just constructed gets stored in
+	// the data section.
+	self.compile_const(Value::Lambda(Shared::new(Lambda {
 	    code, args, locals, rets, captures
-	}))
+	})))
     }
 
-    // Map id to instruction by looking up the value in the scope
-    // chain.
-    pub fn compile_lookup(&mut self, id: &str) -> Result<()> {
+    // Compile a variable reference to a load instruction.
+    pub fn compile_variable_reference(&mut self, id: &str) -> Result<()> {
 	let path = self.scopes.get_path(id)?;
 
 	match (path.frame, path.index) {
-	    (0, index) => self.emit(Instruction::Arg(Binding::Local, index)),
-	    (1, index) => self.emit(Instruction::Arg(Binding::Arg, index)),
+	    (0, index) => self.emit(Instruction::Load(ArgType::Local, index)),
+	    (1, index) => self.emit(Instruction::Load(ArgType::Arg, index)),
 	    _ => {
 		// Captures need special handling.
 		//
@@ -784,20 +1250,23 @@ impl Compiler {
 		// its index in the capture list, not its path in the
 		// lexical scope chain.
 		//
+		// The paths are used at runtime when the lambda is
+		// placed on the stack.
+		//
 		// The capture may or may not already be defined,
-		// which is fine -- captures can be used more than
-		// once -- so we use insert, rather than try_insert.
+		// which is fine -- captures appear more than once --
+		// so we use insert, rather than try_insert.
 		let position = self.captures.insert(id, path)?;
-		self.emit(Instruction::Arg(Binding::Capture, position))
+		self.emit(Instruction::Load(ArgType::Capture, position))
 	    }
 	}
     }
 
     // Emit an instruction to the output.
     //
-    // Since this is a post-order notation, it is convenient for this
-    // function to return Ok(()), since most compile_* functions will
-    // end with this call.
+    // This never fails, but, since this is a post-order notation, it
+    // is convenient for this method to return a result. This saves us
+    // having to end most methods and blocks above with Ok(()).
     pub fn emit(&mut self, inst: Instruction) -> Result<()>{
 	let top = self.blocks.len() - 1;
 	self.blocks[top].push(inst);
@@ -806,7 +1275,10 @@ impl Compiler {
 }
 
 
-// Compile the given path to IR
+/* Public API ****************************************************************/
+
+
+// Convenience function to compile file at `path` to IR.
 pub fn compile(path: &str) -> IR {
     let mut compiler = Compiler::new();
     compiler.compile_program(parser::parse(path)).expect("Compilation Error")

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -335,7 +335,7 @@ pub enum Instruction {
 
 
 // An instruction sequence we can append to
-type Block = Vec<Instruction>;
+pub type Block = Vec<Instruction>;
 
 
 // A location on the stack for captures
@@ -514,7 +514,7 @@ impl Compiler {
     // Try to compile a libray to an IR module.
     pub fn compile_library(
 	&mut self,
-	desc: String,
+	_desc: String,
 	decls: Vec<StmtNode>
     ) -> Result<Module> {
 	self.scopes.push()?;
@@ -579,7 +579,7 @@ impl Compiler {
 	self.emit(Instruction::Def(index))
     }
 
-    pub fn compile_typedef(&mut self, id: &str, expr: &TypeNode) -> Result<()> {
+    pub fn compile_typedef(&mut self, _id: &str, _expr: &TypeNode) -> Result<()> {
 	Error::not_implemented("local typedefs")
     }
 
@@ -762,12 +762,11 @@ impl Compiler {
     // chain.
     pub fn compile_lookup(&mut self, id: &str) -> Result<()> {
 	let path = self.scopes.get_path(id)?;
-	let CapturePath {frame, index} = path;
 
-	match (frame, index) {
-	    (0,     index) => self.emit(Instruction::Arg(Binding::Local, index)),
-	    (1,     index) => self.emit(Instruction::Arg(Binding::Arg, index)),
-	    (frame, index) => {
+	match (path.frame, path.index) {
+	    (0, index) => self.emit(Instruction::Arg(Binding::Local, index)),
+	    (1, index) => self.emit(Instruction::Arg(Binding::Arg, index)),
+	    _ => {
 		// Captures need special handling.
 		//
 		// The positional index of the argument at runtime is

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -584,10 +584,10 @@ impl Compiler {
 	let index = self.scopes.try_insert(id, /* XXX */ Node::new(ast::TypeTag::Any))?;
 	// We need to place the expression representing the value of
 	// the binding onto the stack.
-	self.compile_expr(expr)?;
+	self.compile_expr(expr)
 	// Now we can emit the instruction which will consume the
 	// value and store it in the local stack frame.
-	self.emit(Instruction::Def(index))
+	// self.emit(Instruction::Def(index))
     }
 
     pub fn compile_typedef(&mut self, _id: &str, _expr: &TypeNode) -> Result<()> {
@@ -710,10 +710,10 @@ impl Compiler {
 	func: &ExprNode,
 	args: &[ExprNode]
     ) -> Result<()> {
-	self.compile_expr(func)?;
 	for arg in args {
 	    self.compile_expr(arg)?;
 	}
+	self.compile_expr(func)?;
 	self.emit(Instruction::Call(CallType::Always))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,4 @@ lalrpop_mod!(pub grammar);
 pub mod parser;
 pub mod typechecker;
 pub mod ir;
+pub mod vm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 // <https://www.gnu.org/licenses/>.
 #[macro_use]
 extern crate lalrpop_util;
+extern crate eq_float;
 
 #[macro_use]
 pub mod ast;
@@ -24,3 +25,4 @@ pub mod env;
 lalrpop_mod!(pub grammar);
 pub mod parser;
 pub mod typechecker;
+pub mod ir;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-// uDashBoard: featherweight dashboard application.
+// udlang: stream processing language.
 //
-// Copyright (C) 2019  Brandon Lewis
+// Copyright (C) 2021  Brandon Lewis
 //
 // This program is free software: you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 // <https://www.gnu.org/licenses/>.
 #[macro_use]
 extern crate lalrpop_util;
-extern crate eq_float;
+extern crate ordered_float;
 
 #[macro_use]
 pub mod ast;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
 use std::env;
 use std::fs;
-use std::io;
 
 use udlang::grammar;
 use udlang::ast::{self, Builder};
-use udlang::ir::{self, Compiler};
+use udlang::ir::Compiler;
 
 use std::io::{
     BufReader,
@@ -57,9 +56,9 @@ fn main() {
     let strargs: Vec<&str> = args.iter().map(|i| i.as_str()).collect();
     
     match strargs.as_slice() {
-	[_, ("--dump-expr")] => dump_expr(),
-	[_, ("--dump-ast"), path] => dump_ast(path),
-	[_, ("--compile"), path] => dump_ir(path),
+	[_, "--dump-expr"] => dump_expr(),
+	[_, "--dump-ast", path] => dump_ast(path),
+	[_, "--compile", path] => dump_ir(path),
 	_ => println!("Invalid args. Usage string TBD.")
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,15 @@
 use std::env;
-use std::fs;
 
 use udlang::grammar;
+use udlang::parser::parse;
 use udlang::ast::{self, Builder};
-use udlang::ir::Compiler;
+use udlang::ir::compile;
 
 use std::io::{
     BufReader,
     BufRead,
     stdin
 };
-
-
-// Parse the given path to an AST
-fn parse(path: &str) -> ast::Program {
-    let builder = Builder::new();
-    let contents = fs::read_to_string(path).expect(&format!("Couldn't read file: {}", path));
-    grammar::ProgramParser::new().parse(&builder, &contents).expect("Parse error")
-}
-
-
-// Compile the given path to IR
-fn compile(path: &str) {
-    let mut compiler = Compiler::new();
-    println!("{:?}", compiler.compile_program(parse(path)))
-}
 
 
 // Dump expressions in a REPL

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn dump_ir(path: &str) {
 // Try to decode an ir::Value from a string
 fn decode(_input: std::io::Result<String>) -> Value {
     // XXX: really implement me
-    Value::Bool(false)
+    Value::Int(0)
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
+use std::env;
+use std::fs;
+use std::io;
+
 use udlang::grammar;
-use udlang::ast::Builder;
+use udlang::ast::{self, Builder};
+use udlang::ir::{self, Compiler};
 
 use std::io::{
     BufReader,
@@ -7,16 +12,54 @@ use std::io::{
     stdin
 };
 
-fn dump_expr(text: &str) {
+
+// Parse the given path to an AST
+fn parse(path: &str) -> ast::Program {
     let builder = Builder::new();
-    println!("{:?}", grammar::ExprParser::new().parse(&builder, text));
+    let contents = fs::read_to_string(path).expect(&format!("Couldn't read file: {}", path));
+    grammar::ProgramParser::new().parse(&builder, &contents).expect("Parse error")
 }
 
-fn main() {
+
+// Compile the given path to IR
+fn compile(path: &str) {
+    let mut compiler = Compiler::new();
+    println!("{:?}", compiler.compile_program(parse(path)))
+}
+
+
+// Dump expressions in a REPL
+fn dump_expr() {
+    let builder = Builder::new();
     loop {
 	let mut reader = BufReader::new(stdin());
 	let mut line = String::new();
 	reader.read_line(&mut line).unwrap();
-	dump_expr(&line);
+	println!("{:?}", grammar::ExprParser::new().parse(&builder, &line));
     }
+}
+
+
+// Try to parse `path` and print the resulting AST.
+fn dump_ast(path: &str) {
+    println!("{:?}", parse(path));
+}
+
+
+// Try to compile `path` and print the resulting IR.
+fn dump_ir(path: &str) {
+    println!("{:?}", compile(path))
+}
+
+
+fn main() {
+    let args: Vec<String> = env::args().into_iter().collect();
+    let strargs: Vec<&str> = args.iter().map(|i| i.as_str()).collect();
+    
+    match strargs.as_slice() {
+	[_, ("--dump-expr")] => dump_expr(),
+	[_, ("--dump-ast"), path] => dump_ast(path),
+	[_, ("--compile"), path] => dump_ir(path),
+	_ => println!("Invalid args. Usage string TBD.")
+    };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn dump_ir(path: &str) {
 // Try to decode an ir::Value from a string
 fn decode(_input: std::io::Result<String>) -> Value {
     // XXX: really implement me
-    Value::Int(4)
+    Value::Bool(false)
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn dump_ir(path: &str) {
 // Try to decode an ir::Value from a string
 fn decode(_input: std::io::Result<String>) -> Value {
     // XXX: really implement me
-    Value::Int(3)
+    Value::Int(4)
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,11 @@ use std::env;
 
 use udlang::grammar;
 use udlang::parser::parse;
-use udlang::ast::{self, Builder};
+use udlang::ast::{Builder};
 use udlang::ir::{compile, Value};
 use udlang::vm::run;
 
 use std::io::{
-    BufReader,
     BufRead,
     stdin
 };
@@ -29,20 +28,20 @@ fn dump_expr() {
 
 // Try to parse `path` and print the resulting AST.
 fn dump_ast(path: &str) {
-    println!("{:?}", parse(path));
+    println!("{:#?}", parse(path));
 }
 
 
 // Try to compile `path` and print the resulting IR.
 fn dump_ir(path: &str) {
-    println!("{:?}", compile(path))
+    println!("{:#?}", compile(path))
 }
 
 
 // Try to decode an ir::Value from a string
-fn decode(input: std::io::Result<String>) -> Value {
+fn decode(_input: std::io::Result<String>) -> Value {
     // XXX: really implement me
-    Value::Str("foobar".to_string())
+    Value::Int(3)
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+// (C) 2021 Brandon Lewis
+
 use std::env;
 
 use udlang::grammar;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@ use std::env;
 use udlang::grammar;
 use udlang::parser::parse;
 use udlang::ast::{self, Builder};
-use udlang::ir::compile;
+use udlang::ir::{compile, Value};
+use udlang::vm::run;
 
 use std::io::{
     BufReader,
@@ -15,11 +16,11 @@ use std::io::{
 // Dump expressions in a REPL
 fn dump_expr() {
     let builder = Builder::new();
-    loop {
-	let mut reader = BufReader::new(stdin());
-	let mut line = String::new();
-	reader.read_line(&mut line).unwrap();
-	println!("{:?}", grammar::ExprParser::new().parse(&builder, &line));
+    for line in stdin().lock().lines() {
+	println!(
+	    "{:?}",
+	    grammar::ExprParser::new().parse(&builder, &line.unwrap())
+	);
     }
 }
 
@@ -36,6 +37,13 @@ fn dump_ir(path: &str) {
 }
 
 
+// Try to decode an ir::Value from a string
+fn decode(input: std::io::Result<String>) -> Value {
+    // XXX: really implement me
+    Value::Str("foobar".to_string())
+}
+
+
 fn main() {
     let args: Vec<String> = env::args().into_iter().collect();
     let strargs: Vec<&str> = args.iter().map(|i| i.as_str()).collect();
@@ -44,6 +52,7 @@ fn main() {
 	[_, "--dump-expr"] => dump_expr(),
 	[_, "--dump-ast", path] => dump_ast(path),
 	[_, "--compile", path] => dump_ir(path),
+	[_, path] => run(path, stdin().lock().lines().map(decode)).expect("runtime error"),
 	_ => println!("Invalid args. Usage string TBD.")
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::env;
 use udlang::grammar;
 use udlang::parser::parse;
 use udlang::ast::{Builder};
-use udlang::ir::{compile, Value};
+use udlang::ir::{compile, Value, Shared};
 use udlang::vm::run;
 
 use std::io::{
@@ -41,7 +41,10 @@ fn dump_ir(path: &str) {
 // Try to decode an ir::Value from a string
 fn decode(_input: std::io::Result<String>) -> Value {
     // XXX: really implement me
-    Value::Int(0)
+    Value::List(Shared::new(vec![
+	Value::Str("a".to_string()),
+	Value::Str("b".to_string())
+    ]))
 }
 
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -433,23 +433,28 @@ mod tests {
     #[test]
     fn test_expr_block() {
 	let ast = Builder::new();
-        assert_expr("{let x = y; yield 4}", ast.block(
+        assert_expr("{let x = y; 4}", ast.block(
             &[ast.def("x", ast.id("y"))],
             ast.i(4))
         );
 
-        assert_expr("{let x = frob(y); yield y * 4}", ast.block(
+        assert_expr("{let x = frob(y); y * 4}", ast.block(
             &[ast.def("x", ast.call(ast.id("frob"), &[ast.id("y")]))],
             ast.bin(Mul, ast.id("y"), ast.i(4))
         ));
 
-        assert_expr("{out debug(x); yield x}", ast.block(
+        assert_expr("{out debug(x); x}", ast.block(
             &[ast.emit(ast.call(ast.id("debug"), &[ast.id("x")]))],
             ast.id("x")
         ));
 
+	assert_expr("{out debug(x); done}", ast.block(
+            &[ast.emit(ast.call(ast.id("debug"), &[ast.id("x")]))],
+            ast.void.clone()
+        ));
+
         assert_expr(
-            "{let x = {let y = 2; yield y * 3}; yield x}",
+            "{let x = {let y = 2;  y * 3}; x}",
             ast.block(
 		&[
                     ast.def("x",
@@ -471,6 +476,7 @@ mod tests {
               for p in points {
                   out ["moveto", p];
                   out ["circle", 50.0];
+                  done
               }
         "#;
 
@@ -497,6 +503,7 @@ mod tests {
               for (k, p) in x {
                   out ["moveto", [p.x, p.y]];
                   out ["text", k];
+                  done
               }
         "#;
 
@@ -523,7 +530,7 @@ mod tests {
     fn test_if() {
 	let ast = Builder::new();
         assert_statement(
-            "if (a) { out [\"text\", b]; }",
+            "if (a) { out [\"text\", b]; done}",
             ast.guard(
                 &[(ast.id("a"),
 		   ast.block(
@@ -540,7 +547,7 @@ mod tests {
     fn test_if_else() {
 	let ast = Builder::new();
         assert_statement(
-            r#"if (a) { out a; } else { out "error"; }"#,
+            r#"if (a) { out a; done} else { out "error"; done}"#,
             ast.guard(
                 &[(ast.id("a"),
 		   ast.block(
@@ -558,11 +565,11 @@ mod tests {
 	let ast = Builder::new();
         assert_statement(
             r#"if (a) {
-               out "a";
+               out "a"; done
             } elif (b) {
-               out "b";
+               out "b"; done
             } else {
-               out "error";
+               out "error"; done
             }"#,
             ast.guard(
                 &[
@@ -575,13 +582,13 @@ mod tests {
 
         assert_statement(
             r#"if (a) {
-               out "a";
+               out "a"; done
             } elif (b) {
-               out "b";
+               out "b"; done
             } elif (c) {
-               out "c";
+               out "c"; done
             } else {
-               out "error";
+               out "error"; done
             }"#,
             ast.guard(
                 &[
@@ -599,9 +606,9 @@ mod tests {
 	let ast = Builder::new();
         assert_statement(
             r#"if (a) {
-               out "a";
+               out "a"; done
             } elif (b) {
-               out "b";
+               out "b"; done
             }"#,
             ast.guard(
                 &[
@@ -614,11 +621,11 @@ mod tests {
 
         assert_statement(
             r#"if (a) {
-               out "a";
+               out "a"; done
             } elif (b) {
-               out "b";
+               out "b"; done
             } elif (c) {
-               out "c";
+               out "c"; done
             }"#,
             ast.guard(
                 &[
@@ -639,7 +646,7 @@ mod tests {
         ));
 
         assert_statement(
-            "foo() { out \"paint\";}",
+            "foo() { out \"paint\"; done}",
             ast.template_call(ast.id("foo"), &[], ast.block(
 		&[ast.emit(ast.s("paint"))],
 		ast.void.clone()
@@ -652,8 +659,10 @@ mod tests {
                 bar(y, z) {
                    gronk();
                    frobulate();
+                   done
                 }
                 frobulate();
+                done
             }
             "#,
             ast.template_call(
@@ -761,7 +770,7 @@ mod tests {
 
 	assert_statement(
 	    r#"
-            for i in in { out i; }
+            for i in in { out i; done}
             "#,
 	    ast.list_iter(
 		"i",
@@ -774,7 +783,7 @@ mod tests {
 
 	assert_statement(
 	    r#"
-            for i in in.items { out i; }
+            for i in in.items { out i; done}
             "#,
 	    ast.list_iter(
 		"i",
@@ -997,7 +1006,7 @@ mod tests {
     fn test_statement_function_def() {
 	let ast = Builder::new();
         assert_statement(
-            r#"func foo(y: Int) -> Int {yield 4 * y}"#,
+            r#"func foo(y: Int) -> Int {4 * y}"#,
             ast.def(
                 "foo",
                 ast.lambda(
@@ -1010,7 +1019,7 @@ mod tests {
 
         assert_statement(
             r#"proc foo(y: Int) {
-               out "paint";
+               out "paint"; done
             }"#,
             ast.def(
                 "foo",
@@ -1246,8 +1255,10 @@ mod tests {
                ...;
                ...;
                ...;
+               done
             } else {
                out "Yesterdayyyyyy.....";
+               done
             }
             "#,
 	    ast.suppose(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -688,6 +688,22 @@ mod tests {
             ast.lambda(&[], ast.t_void.clone(), ast.map(&[]))
         );
 
+	let ast = Builder::new();
+        assert_expr(
+            "() {{}}",
+            ast.lambda(&[], ast.t_void.clone(), ast.map(&[]))
+        );
+
+        assert_expr(
+            "() {done}",
+            ast.lambda(&[], ast.t_void.clone(), ast.void.clone())
+        );
+
+	assert_expr(
+            "() {4}",
+            ast.lambda(&[], ast.t_void.clone(), ast.i(4))
+        );
+
         assert_expr(
             "() = 4",
             ast.lambda(&[], ast.t_void.clone(), ast.i(4))
@@ -700,7 +716,7 @@ mod tests {
         );
 
         assert_expr(
-            "() = {let x = 4; yield x}",
+            "() {let x = 4; x}",
             ast.lambda(
 		&[],
                 ast.t_void.clone(),
@@ -849,13 +865,13 @@ mod tests {
                field x: Float;
                field y: Float;
 
-               method dist(other: Self) -> Float = {
+               method dist(other: Self) -> Float {
                   let dx = self.x - other.x;
                   let dy = self.y - other.y;
-                  yield sqrt(dx * dx + dy * dy)
+                  sqrt(dx * dx + dy * dy)
                };
 
-               static fromPolar(r: Float, theta: Float) -> Self = {
+               static fromPolar(r: Float, theta: Float) -> Self {
                   x: r * cos(theta),
                   y: r * sin(theta),
                };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -514,13 +514,13 @@ mod tests {
 	let parse = ast.list_iter(
 	    "p",
 	    ast.id("points"),
-	    ast.expr_for_effect(ast.block(
+	    ast.block(
 		&[
 		    ast.out(ast.list(&[ast.s("moveto"), ast.id("p")])),
 		    ast.out(ast.list(&[ast.s("circle"), ast.f(50.0)]))
 		],
 		ast.void.clone()
-	    ))
+	    )
         );
 
         assert_statement(test, parse);
@@ -540,7 +540,7 @@ mod tests {
 	let parse = ast.map_iter(
 	    "k", "p",
 	    ast.id("x"),
-	    ast.expr_for_effect(ast.block(
+	    ast.block(
 		&[
 		    ast.out(ast.list(&[
 			ast.s("moveto"),
@@ -550,7 +550,7 @@ mod tests {
 		    ast.out(ast.list(&[ast.s("text"), ast.id("k")]))
 		],
 		ast.void.clone()
-	    ))
+	    )
 	);
 
         assert_statement(test, parse);
@@ -810,9 +810,7 @@ mod tests {
 	    ast.list_iter(
 		"i",
 		ast.in_.clone(),
-		ast.expr_for_effect(
-		    ast.block(&[ast.out(ast.id("i"))], ast.void.clone())
-		)
+		ast.block(&[ast.out(ast.id("i"))], ast.void.clone())
 	    )
 	);
 
@@ -823,9 +821,7 @@ mod tests {
 	    ast.list_iter(
 		"i",
 		ast.dot(ast.in_.clone(), "items"),
-		ast.expr_for_effect(
-		    ast.block(&[ast.out(ast.id("i"))], ast.void.clone())
-		)
+		ast.block(&[ast.out(ast.id("i"))], ast.void.clone())
 	    )
 	);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,5 @@
+// (C) 2021 Brandon Lewis
+//
 // Mostly just a place to hold the unit tests for the grammar. The
 // actual parser is just a wrapper around what LALRPOP has generated for us.
 //
@@ -418,10 +420,10 @@ mod tests {
     #[test]
     fn test_simple_statement() {
 	let ast = Builder::new();
-        assert_statement("out \"fill\";", ast.emit(ast.s("fill")));
+        assert_statement("out \"fill\";", ast.out(ast.s("fill")));
         assert_statement(
             "out moveto(x, y);",
-            ast.emit(ast.call(ast.id("moveto"), &[ast.id("x"), ast.id("y")]))
+            ast.out(ast.call(ast.id("moveto"), &[ast.id("x"), ast.id("y")]))
         );
 
         assert_statement(
@@ -444,7 +446,7 @@ mod tests {
         ));
 
         assert_expr("{out debug(x); x}", ast.block(
-            &[ast.emit(ast.call(ast.id("debug"), &[ast.id("x")]))],
+            &[ast.out(ast.call(ast.id("debug"), &[ast.id("x")]))],
             ast.id("x")
         ));
 
@@ -479,7 +481,7 @@ mod tests {
 
         assert_statement(
 	    "{out debug(x);}",
-	    ast.emit(ast.call(ast.id("debug"), &[ast.id("x")]))
+	    ast.out(ast.call(ast.id("debug"), &[ast.id("x")]))
 	);
 
         assert_statement(
@@ -492,7 +494,7 @@ mod tests {
 				ast.bin(Mul, ast.id("y"), ast.i(3))
 			    )
                     ),
-		    ast.emit(ast.id("x"))
+		    ast.out(ast.id("x"))
 		],
 		ast.void.clone()
 	    ))
@@ -514,8 +516,8 @@ mod tests {
 	    ast.id("points"),
 	    ast.expr_for_effect(ast.block(
 		&[
-		    ast.emit(ast.list(&[ast.s("moveto"), ast.id("p")])),
-		    ast.emit(ast.list(&[ast.s("circle"), ast.f(50.0)]))
+		    ast.out(ast.list(&[ast.s("moveto"), ast.id("p")])),
+		    ast.out(ast.list(&[ast.s("circle"), ast.f(50.0)]))
 		],
 		ast.void.clone()
 	    ))
@@ -540,12 +542,12 @@ mod tests {
 	    ast.id("x"),
 	    ast.expr_for_effect(ast.block(
 		&[
-		    ast.emit(ast.list(&[
+		    ast.out(ast.list(&[
 			ast.s("moveto"),
 			ast.list(&[ast.dot(ast.id("p"), "x"),
 				   ast.dot(ast.id("p"), "y")])
 		    ])),
-		    ast.emit(ast.list(&[ast.s("text"), ast.id("k")]))
+		    ast.out(ast.list(&[ast.s("text"), ast.id("k")]))
 		],
 		ast.void.clone()
 	    ))
@@ -562,7 +564,7 @@ mod tests {
             ast.guard(
                 &[(ast.id("a"),
 		   ast.block(
-		       &[ast.emit(ast.list(&[ast.s("text"), ast.id("b")]))],
+		       &[ast.out(ast.list(&[ast.s("text"), ast.id("b")]))],
 		       ast.void.clone()
 		   ))
 		],
@@ -579,11 +581,11 @@ mod tests {
             ast.guard(
                 &[(ast.id("a"),
 		   ast.block(
-		       &[ast.emit(ast.id("a"))],
+		       &[ast.out(ast.id("a"))],
 		       ast.void.clone()
 		   ))
 		],
-                Some(ast.emit(ast.s("error")))
+                Some(ast.out(ast.s("error")))
             )
         );
     }
@@ -601,10 +603,10 @@ mod tests {
             }"#,
             ast.guard(
                 &[
-                    (ast.id("a"), ast.block(&[ast.emit(ast.s("a"))], ast.void.clone())),
-                    (ast.id("b"), ast.block(&[ast.emit(ast.s("b"))], ast.void.clone())),
+                    (ast.id("a"), ast.block(&[ast.out(ast.s("a"))], ast.void.clone())),
+                    (ast.id("b"), ast.block(&[ast.out(ast.s("b"))], ast.void.clone())),
                 ],
-                Some(ast.emit(ast.s("error")))
+                Some(ast.out(ast.s("error")))
             )
         );
 
@@ -620,11 +622,11 @@ mod tests {
             }"#,
             ast.guard(
                 &[
-                    (ast.id("a"), ast.block(&[ast.emit(ast.s("a"))], ast.void.clone())),
-                    (ast.id("b"), ast.block(&[ast.emit(ast.s("b"))], ast.void.clone())),
-                    (ast.id("c"), ast.block(&[ast.emit(ast.s("c"))], ast.void.clone())),
+                    (ast.id("a"), ast.block(&[ast.out(ast.s("a"))], ast.void.clone())),
+                    (ast.id("b"), ast.block(&[ast.out(ast.s("b"))], ast.void.clone())),
+                    (ast.id("c"), ast.block(&[ast.out(ast.s("c"))], ast.void.clone())),
                 ],
-                Some(ast.emit(ast.s("error")))
+                Some(ast.out(ast.s("error")))
             )
         );
     }
@@ -640,8 +642,8 @@ mod tests {
             }"#,
             ast.guard(
                 &[
-                    (ast.id("a"), ast.block(&[ast.emit(ast.s("a"))], ast.void.clone())),
-                    (ast.id("b"), ast.block(&[ast.emit(ast.s("b"))], ast.void.clone())),
+                    (ast.id("a"), ast.block(&[ast.out(ast.s("a"))], ast.void.clone())),
+                    (ast.id("b"), ast.block(&[ast.out(ast.s("b"))], ast.void.clone())),
                 ],
                 None
             )
@@ -657,9 +659,9 @@ mod tests {
             }"#,
             ast.guard(
                 &[
-                    (ast.id("a"), ast.block(&[ast.emit(ast.s("a"))], ast.void.clone())),
-                    (ast.id("b"), ast.block(&[ast.emit(ast.s("b"))], ast.void.clone())),
-                    (ast.id("c"), ast.block(&[ast.emit(ast.s("c"))], ast.void.clone())),
+                    (ast.id("a"), ast.block(&[ast.out(ast.s("a"))], ast.void.clone())),
+                    (ast.id("b"), ast.block(&[ast.out(ast.s("b"))], ast.void.clone())),
+                    (ast.id("c"), ast.block(&[ast.out(ast.s("c"))], ast.void.clone())),
                 ],
                 None
             )
@@ -676,7 +678,7 @@ mod tests {
         assert_statement(
             "foo() { out \"paint\";}",
             ast.template_call(ast.id("foo"), &[], ast.block(
-		&[ast.emit(ast.s("paint"))],
+		&[ast.out(ast.s("paint"))],
 		ast.void.clone()
 	    ))
         );
@@ -809,7 +811,7 @@ mod tests {
 		"i",
 		ast.in_.clone(),
 		ast.expr_for_effect(
-		    ast.block(&[ast.emit(ast.id("i"))], ast.void.clone())
+		    ast.block(&[ast.out(ast.id("i"))], ast.void.clone())
 		)
 	    )
 	);
@@ -822,7 +824,7 @@ mod tests {
 		"i",
 		ast.dot(ast.in_.clone(), "items"),
 		ast.expr_for_effect(
-		    ast.block(&[ast.emit(ast.id("i"))], ast.void.clone())
+		    ast.block(&[ast.out(ast.id("i"))], ast.void.clone())
 		)
 	    )
 	);
@@ -1059,7 +1061,7 @@ mod tests {
                 ast.lambda(
                     &alist!{"y" => ast.t_int.clone()},
                     ast.t_void.clone(),
-                    ast.block(&[ast.emit(ast.s("paint"))], ast.void.clone())
+                    ast.block(&[ast.out(ast.s("paint"))], ast.void.clone())
                 )
             )
         );
@@ -1295,13 +1297,13 @@ mod tests {
 	    ast.suppose(
 		ast.call(ast.id("she_may_love_you"), &[]),
 		ast.expr_for_effect(ast.block(&[
-		    ast.emit(ast.s("She loves you,")),
+		    ast.out(ast.s("She loves you,")),
 		    ast.effect_capture.clone(),
 		    ast.effect_capture.clone(),
 		    ast.effect_capture.clone()
 		], ast.void.clone())),
 		ast.expr_for_effect(ast.block(&[
-		    ast.emit(ast.s("Yesterdayyyyyy....."))
+		    ast.out(ast.s("Yesterdayyyyyy....."))
 		], ast.void.clone()))
 	    )
 	);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,13 +7,29 @@
 //
 // LALRPOP lets us test each production in isolation, as well as for
 // the grammar as a whole.
+use std::fs;
+
+use crate::grammar;
+use crate::ast;
+use crate::ast::*;
+
+
+// Parse the given path to an AST
+pub fn parse(path: &str) -> ast::Program {
+    let builder = Builder::new();
+
+    let contents = fs::read_to_string(path)
+	.expect(&format!("Couldn't read file: {}", path));
+
+    grammar::ProgramParser::new()
+	.parse(&builder, &contents)
+	.expect("Syntax Error")
+}
 
 
 #[cfg(test)]
 mod tests {
-    use crate::grammar;
-    use crate::ast;
-    use crate::ast::*;
+    use super::*;
     use ast::BinOp::*;
     use ast::UnOp::*;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1292,15 +1292,15 @@ mod tests {
             "#,
 	    ast.suppose(
 		ast.call(ast.id("she_may_love_you"), &[]),
-		ast.expr_for_effect(ast.block(&[
+		ast.block(&[
 		    ast.out(ast.s("She loves you,")),
 		    ast.effect_capture.clone(),
 		    ast.effect_capture.clone(),
 		    ast.effect_capture.clone()
-		], ast.void.clone())),
-		ast.expr_for_effect(ast.block(&[
+		], ast.void.clone()),
+		ast.block(&[
 		    ast.out(ast.s("Yesterdayyyyyy....."))
-		], ast.void.clone()))
+		], ast.void.clone())
 	    )
 	);
     }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -346,7 +346,7 @@ impl TypeChecker {
             Statement::ExprForEffect(body) => {
                 self.is_void(body)?;
             },
-            Statement::Emit(_expr) =>
+            Statement::Out(_expr) =>
    	        /* XXX: expr must resolve to the declared output type */
 		Err(TypeError::NotImplemented)?,
             Statement::Def(name, val) => {
@@ -564,7 +564,7 @@ mod tests {
         let statement = Node::new(ast.list_iter(
             "i",
             ast.id("x"),
-            ast.emit(ast.list(&[ast.s("show_text"), ast.id("i")]))
+            ast.out(ast.list(&[ast.s("show_text"), ast.id("i")]))
         ));
 
         assert_eq!(tc.check_statement(&statement), Err(NotImplemented));
@@ -595,7 +595,7 @@ mod tests {
             "k",
             "v",
             ast.id("x"),
-            ast.emit(ast.list(&[ast.s("show_text"), ast.id("v")]))
+            ast.out(ast.list(&[ast.s("show_text"), ast.id("v")]))
         ));
 
         assert_eq!(tc.check_statement(&statement), Err(NotImplemented));

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -417,10 +417,8 @@ impl TypeChecker {
 mod tests {
     use super::*;
     #[allow(unused_imports)]
-    #[macro_use]
     use crate::ast;
     #[allow(unused_imports)]
-    #[macro_use]
     use crate::ast::*;
 
     // Assert that expr evaluated in env has type t.

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -360,7 +360,7 @@ impl TypeChecker {
                 let env = Env::chain(&self.types);
                 let sub = TypeChecker::new(env);
                 sub.types.define(iter, &item);
-                sub.check_statement(body)?;
+                sub.eval_expr(body)?;
             },
             Statement::MapIter(k, v, map, body) => {
                 // TODO: raise proper error, rather than crashing.
@@ -370,11 +370,11 @@ impl TypeChecker {
                 let sub = TypeChecker::new(env);
                 sub.types.define(k, &Node::new(TypeTag::Str));
                 sub.types.define(v, &item);
-                sub.check_statement(body)?;
+                sub.eval_expr(&body)?;
             },
             Statement::While(cond, body) => {
                 self.is_bool(cond)?;
-                self.check_statement(body)?;
+                self.check_statement(&body)?;
             },
         };
         Ok(())
@@ -564,7 +564,7 @@ mod tests {
         let statement = Node::new(ast.list_iter(
             "i",
             ast.id("x"),
-            ast.out(ast.list(&[ast.s("show_text"), ast.id("i")]))
+            ast.block(&[ast.out(ast.list(&[ast.s("show_text"), ast.id("i")]))], ast.void.clone())
         ));
 
         assert_eq!(tc.check_statement(&statement), Err(NotImplemented));
@@ -572,7 +572,7 @@ mod tests {
         let statement = Node::new(ast.list_iter(
             "i",
             ast.id("x"),
-            ast.expr_for_effect(ast.block(&[], ast.id("i")))
+            ast.block(&[], ast.id("i"))
         ));
 
         assert_eq!(
@@ -595,7 +595,7 @@ mod tests {
             "k",
             "v",
             ast.id("x"),
-            ast.out(ast.list(&[ast.s("show_text"), ast.id("v")]))
+            ast.block(&[ast.out(ast.list(&[ast.s("show_text"), ast.id("v")]))], ast.void.clone())
         ));
 
         assert_eq!(tc.check_statement(&statement), Err(NotImplemented));
@@ -604,7 +604,7 @@ mod tests {
             "k",
             "v",
             ast.id("x"),
-            ast.expr_for_effect(ast.block(&[], ast.id("v")))
+            ast.block(&[ast.expr_for_effect(ast.block(&[], ast.id("v")))], ast.void.clone())
         ));
 
         assert_eq!(

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -372,10 +372,6 @@ impl TypeChecker {
                 sub.types.define(v, &item);
                 sub.eval_expr(&body)?;
             },
-            Statement::While(cond, body) => {
-                self.is_bool(cond)?;
-                self.check_statement(&body)?;
-            },
         };
         Ok(())
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -440,7 +440,7 @@ impl VM {
 	let pos = pos as usize;
 	let value = self.stack.pop()?;
 	let frame = self.stack.top_frame_mut()?;
-	if pos < frame.values.len() {
+	if pos <= frame.values.len() {
 	    frame.values[pos + frame.args as usize] = value;
 	    Ok(())
 	} else {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,0 +1,182 @@
+use crate::ir::{
+    Executable,
+    Instruction,
+    IR,
+    Value,
+    compile,
+};
+
+
+use std::fmt::Debug;
+use std::rc::Rc;
+
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error {
+    StackUnderflow,
+    StackOverflow,
+    IllegalAddr(String),
+    TypeError(String),
+    NotImplemented(String),
+    Internal(String),
+}
+
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+
+impl Error {
+    pub fn stack_underflow<T>() -> Result<T> {
+	Err(Self::StackUnderflow)
+    }
+
+    pub fn stack_overflow<T>() -> Result<T> {
+	Err(Self::StackUnderflow)
+    }
+
+    pub fn illegal_addr<T>(addr: usize) -> Result<T> {
+	Err(Self::IllegalAddr(format!("Illegal Address: {:?}", addr)))
+    }
+
+    pub fn type_error<T: Debug, U>(expected: T, got: T) -> Result<U> {
+	Err(Self::TypeError(format!("Expected {:?}, got {:?}", expected, got)))
+    }
+
+    pub fn not_implemented<T>(feature: &str) -> Result<T> {
+	Err(Self::NotImplemented(format!("{:?} is not implemented", feature)))
+    }
+
+    pub fn internal<T>(mumbo_jumbo: &str) -> Result<T> {
+	Err(Self::Internal(mumbo_jumbo.to_string()))
+    }
+}
+
+
+// Conveneince function to compile and run the script at the given path.
+pub fn run<S> (path: &str, input: S) -> Result<()>
+where S: Iterator<Item = Value> {
+    let program = match compile(path) {
+	IR::Executable(e) => e,
+	IR::Module(_) => panic!("You cannot execute a library as a script!")
+    };
+
+    VM::new(program).run(input)
+}
+
+    
+// Holds the state we need to execute instructions sequentially.
+pub struct VM {
+    script: Executable,
+    stack: Vec<Value>,
+    input: Option<Value>,
+}
+
+
+// This is the high-level interface for our VM.
+impl VM {
+    // Allocate and initialize a new virtual machine
+    pub fn new(script: Executable) -> VM {
+	let stack = Vec::new();
+	let input = None;
+	VM {script, stack, input}
+    }
+
+    // Run the given script until the input iterator is exhausted.
+    pub fn run<S: Iterator<Item = Value>>(
+	&mut self,
+	input: S,
+    ) -> Result<()> {
+	self.init()?;
+	Ok(for value in input {
+	    self.main(value)?;
+	})
+    }
+
+    // Execute the init block in the script.
+    pub fn init(&mut self) -> Result<()> {
+	// XXX: It really bothers me that we can't just borrow this.
+	let block = self.script.code[0].clone();
+	self.exec_block(&block)
+    }
+
+    // Execute the main block in the script.
+    pub fn main(&mut self, input: Value) -> Result<()> {
+	// XXX: It really bothers me that we can't just borrow this.
+	let block = self.script.code[1].clone();
+	self.input = Some(input);
+	self.exec_block(&block)
+    }
+
+    // Execute each instruction in the given block.
+    fn exec_block(&mut self, block: &[Instruction]) -> Result<()> {
+	Ok(for insn in block {
+	    self.exec_insn(insn)?;
+	})
+    }
+
+    // Execute the given instruction.
+    fn exec_insn(&mut self, insn: &Instruction) -> Result<()> {
+	use Instruction::*;
+	match insn {
+	    Const(addr) => {
+		let x = &self.script.data[*addr as usize].clone();
+		self.push(&x)
+	    },
+	    Arg(_, _) => Error::not_implemented("Arg instruction"),
+	    Def(_) => Error::not_implemented("Local var"),
+	    Un(_) => Error::not_implemented("Unary operator"),
+	    Bin(_) => Error::not_implemented("Binary operator"),
+	    Call(_) => Error::not_implemented("Function call"),
+	    In => self.push(&self.input.clone().expect("No input record")),
+	    Out => {println!("{:?}", self.pop()?); Ok(())},
+	     /* XXX: should be stderr */
+	    Debug => {println!("{:?}", self.peek(0)?); Ok(())},
+	    Drop(n) => self.drop(*n),
+	    Dup(n) => self.dup(*n),
+	    Swap(x, y) => self.swap(*x, *y),
+	    Placeholder => Error::not_implemented("Partial application"),
+	    Index(_) => Error::not_implemented("Indexing into collection"),
+	    Matches => Error::not_implemented("Type query"),
+	    Coerce => Error::not_implemented("Type cast")
+	}
+    }
+
+    fn push(&mut self, value: &Value) -> Result<()> {
+	self.stack.push(value.clone());
+	Ok(())
+    }
+
+    fn pop(&mut self) -> Result<Value> {
+	if let Some(value) = self.stack.pop() {
+	    Ok(value)
+	} else {
+	    Error::stack_underflow()
+	}
+    }
+
+    fn peek(&self, rel: u8) -> Result<&Value> {
+	let len = self.stack.len();
+	if len > 0 {
+	    Ok(&self.stack[len - 1 - rel as usize])
+	} else {
+	    Error::stack_underflow()
+	}
+    }
+
+    fn dup(&mut self, n: u8) -> Result<()> {
+	let top = self.peek(0)?.clone();
+	Ok(for _ in 0..n {
+	    self.push(&top)?;
+	})
+    }
+
+    fn drop(&mut self, n: u8) -> Result<()> {
+	Ok(for _ in 0..n {
+	    self.pop()?;
+	})
+    }
+
+    fn swap(&mut self, _: u8, _: u8) -> Result<()> {
+	Error::not_implemented("swap instruction")
+    }
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -270,15 +270,15 @@ impl Stack {
     }
 
     // Load the given local onto the stack.
-    pub fn load(&mut self, atom: Atom) -> Result<()> {
+    pub fn load(&mut self, atom: &Atom) -> Result<()> {
 	let value = self.get_local(atom)?;
 	self.push(value)
     }
 
     // Find the given local somewhere in the call stack.
-    fn get_local(&mut self, atom: Atom) -> Result<Value> {
+    fn get_local(&mut self, atom: &Atom) -> Result<Value> {
 	for frame in self.frames.iter().rev() {
-	    if let Some(value) = frame.locals.get(&atom) {
+	    if let Some(value) = frame.locals.get(atom) {
 		return Ok(value.clone());
 	    }
 	}
@@ -286,10 +286,10 @@ impl Stack {
     }
 
     // Store the given local to the call stack.
-    fn store(&mut self, atom: Atom) -> Result<()> {
+    fn store(&mut self, atom: &Atom) -> Result<()> {
 	let value = self.pop()?;
 	let frame = self.top_frame_mut()?;
-	frame.locals.insert(atom, value);
+	frame.locals.insert(atom.clone(), value);
 	Ok(())
     }
 }
@@ -415,8 +415,8 @@ impl VM {
 	eprintln!("\n\nExec: {:?}", insn);
 	match insn {
 	    Const(addr)       => self.load_const(*addr),
-	    Load(atom)        => self.load_arg(*atom),
-	    Store(index)      => self.store(*index),
+	    Load(atom)        => self.load_arg(atom),
+	    Store(atom)       => self.store(atom),
 	    Un(opcode)        => self.unop(*opcode),
 	    Bin(opcode)       => self.binop(*opcode),
 	    Call(ct)          => self.call(*ct),	    
@@ -458,12 +458,12 @@ impl VM {
     }
 
     // Copy an argument or captured value to the top of stack.
-    fn load_arg(&mut self, id: Atom) -> Result<()> {
+    fn load_arg(&mut self, id: &Atom) -> Result<()> {
 	self.stack.load(id)
     }
 
     // Shuffle an local variable to the correct stack slot position.
-    fn store(&mut self, id: Atom) -> Result<()> {
+    fn store(&mut self, id: &Atom) -> Result<()> {
 	self.stack.store(id)
     }
 


### PR DESCRIPTION
- Implements parts of #36 
- Fixes #5 

This is roughly the simplest design I could come up with, and doesn't fulfill most promises uDLang makes, but at least it gets uDLang out of vapor-ware territory, and into a state  that can actually execute (some) code.

The goal of the `ir` module is to perform the simplest possible lowering pass from the AST into executable IR. A VM capable of executing the IR is provided to help validate the IR design itself.

The thinking is to use #37 #38 to perform deeper analysis and optimization, and this will need to be combined with tracking of source information.

Source location information is not yet available from the parser, let alone stored in the AST. So we cannot yet generate source maps for the IR, but this is planned.